### PR TITLE
Enable tests on pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
-name: Deploy to Raspberry Pi
+name: CI/CD Pipeline
 
 on:
   push:
+    branches: [ main ]
+  pull_request:
     branches: [ main ]
 
 jobs:
@@ -56,6 +58,7 @@ jobs:
   deploy:
     needs: test
     runs-on: self-hosted
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- Run tests on both pushes to main and pull requests
- Deploy only runs on pushes to main (not on PRs)
- This allows catching issues before merging

🤖 Generated with [Claude Code](https://claude.ai/code)