### PR TITLE
feat: add recurring expenses feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from sqlalchemy import extract
 from subprocess import run, CalledProcessError
 from pathlib import Path
 import glob
+from apscheduler.schedulers.background import BackgroundScheduler
 
 # Configure logging
 logging.basicConfig(
@@ -55,6 +56,49 @@ class Expense(db.Model):
         }
 
 
+class RecurringExpense(db.Model):
+    __tablename__ = "recurring_expense"
+
+    id = db.Column(db.Integer, primary_key=True)
+    amount = db.Column(db.Float, nullable=False)
+    category = db.Column(db.String(50), nullable=False)
+    description = db.Column(db.String(50), nullable=False)
+
+    # Recurrence config
+    frequency = db.Column(
+        db.String(20), nullable=False, default="monthly"
+    )  # monthly, weekly, yearly
+    day_of_month = db.Column(
+        db.Integer, nullable=True
+    )  # 1-31 for monthly, 1-7 for weekly (Mon=1)
+
+    # Lifecycle
+    start_date = db.Column(db.DateTime, nullable=False)
+    end_date = db.Column(db.DateTime, nullable=True)  # NULL = no end
+    is_active = db.Column(db.Boolean, default=True)
+
+    # Tracking
+    last_applied_date = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "amount": self.amount,
+            "category": self.category,
+            "description": self.description,
+            "frequency": self.frequency,
+            "day_of_month": self.day_of_month,
+            "start_date": self.start_date.isoformat() if self.start_date else None,
+            "end_date": self.end_date.isoformat() if self.end_date else None,
+            "is_active": self.is_active,
+            "last_applied_date": (
+                self.last_applied_date.isoformat() if self.last_applied_date else None
+            ),
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+
+
 # Initialize database
 try:
     with app.app_context():
@@ -62,6 +106,115 @@ try:
         logger.info("Database initialized successfully")
 except Exception as e:
     logger.error(f"Error initializing database: {e}")
+
+
+# Recurring expense application logic
+def apply_due_recurring_expenses():
+    """Apply recurring expenses that are due today."""
+    with app.app_context():
+        try:
+            today = datetime.now(timezone.utc).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            logger.info(f"Checking for due recurring expenses on {today.date()}")
+
+            # Query active recurring expenses
+            recurring_expenses = (
+                RecurringExpense.query.filter(
+                    RecurringExpense.is_active.is_(True),
+                    RecurringExpense.start_date <= today,
+                )
+                .filter(
+                    (RecurringExpense.end_date.is_(None))
+                    | (RecurringExpense.end_date >= today)
+                )
+                .all()
+            )
+
+            applied_count = 0
+            for recurring in recurring_expenses:
+                if is_due_today(recurring, today):
+                    # Check for duplicate
+                    existing = Expense.query.filter(
+                        Expense.amount == recurring.amount,
+                        Expense.category == recurring.category,
+                        Expense.description == recurring.description,
+                        extract("year", Expense.date) == today.year,
+                        extract("month", Expense.date) == today.month,
+                        extract("day", Expense.date) == today.day,
+                    ).first()
+
+                    if not existing:
+                        # Create new expense
+                        expense = Expense(
+                            amount=recurring.amount,
+                            category=recurring.category,
+                            description=recurring.description,
+                            date=today,
+                        )
+                        db.session.add(expense)
+                        recurring.last_applied_date = today
+                        applied_count += 1
+                        logger.info(
+                            f"Applied recurring: {recurring.description}"
+                        )
+                    else:
+                        logger.info(
+                            f"Skipping duplicate: {recurring.description}"
+                        )
+
+            db.session.commit()
+            logger.info(f"Applied {applied_count} recurring expenses")
+            return applied_count
+
+        except Exception as e:
+            logger.error(f"Error applying recurring expenses: {e}")
+            db.session.rollback()
+            return 0
+
+
+def is_due_today(recurring, today):
+    """Check if a recurring expense is due today."""
+    # If never applied, check if start_date is today or earlier
+    if recurring.last_applied_date is None:
+        return True
+
+    last_applied = recurring.last_applied_date.replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+    if recurring.frequency == "monthly":
+        # Due if it's the specified day of month and not applied this month
+        if recurring.day_of_month and today.day == recurring.day_of_month:
+            return last_applied.year != today.year or last_applied.month != today.month
+        return False
+
+    elif recurring.frequency == "weekly":
+        # Due if it's the specified day of week and not applied this week
+        if recurring.day_of_month:  # Using day_of_month for weekday (1=Monday)
+            if today.isoweekday() == recurring.day_of_month:
+                days_since_last = (today - last_applied).days
+                return days_since_last >= 7
+        return False
+
+    elif recurring.frequency == "yearly":
+        # Due if it's the same day and month, and not applied this year
+        if recurring.day_of_month and today.day == recurring.day_of_month:
+            start_month = recurring.start_date.month
+            if today.month == start_month:
+                return last_applied.year != today.year
+        return False
+
+    return False
+
+
+# Initialize scheduler
+scheduler = BackgroundScheduler()
+scheduler.add_job(
+    apply_due_recurring_expenses, "cron", hour=0, minute=0, id="apply_recurring"
+)
+scheduler.start()
+logger.info("Scheduler started for recurring expenses")
 
 
 @app.after_request
@@ -109,6 +262,11 @@ def serve_add():
 @app.route("/expenses")
 def serve_expenses():
     return send_from_directory("static", "expenses.html")
+
+
+@app.route("/recurring")
+def serve_recurring():
+    return send_from_directory("static", "recurring.html")
 
 
 @app.route("/styles.css")
@@ -323,6 +481,220 @@ def download_backup():
         download_name=Path(latest_file).name,
         mimetype="text/csv",
     )
+
+
+# Recurring expense API endpoints
+@app.route("/api/recurring", methods=["GET", "POST"])
+def handle_recurring_expenses():
+    if request.method == "POST":
+        try:
+            data = request.get_json()
+            if data is None:
+                return jsonify({"error": "No JSON data received"}), 400
+
+            # Validate required fields
+            required_fields = [
+                "amount",
+                "category",
+                "description",
+                "frequency",
+                "start_date",
+            ]
+            for field in required_fields:
+                if field not in data:
+                    return (
+                        jsonify({"error": f"{field.capitalize()} field is required"}),
+                        400,
+                    )
+
+            # Validate amount
+            try:
+                amount = float(data["amount"])
+            except (ValueError, TypeError):
+                return jsonify({"error": "Invalid amount value"}), 400
+
+            # Validate frequency
+            valid_frequencies = ["monthly", "weekly", "yearly"]
+            if data["frequency"] not in valid_frequencies:
+                return jsonify({"error": "Invalid frequency"}), 400
+
+            # Parse dates
+            try:
+                start_date = datetime.fromisoformat(
+                    data["start_date"].replace("Z", "+00:00")
+                )
+            except (ValueError, AttributeError):
+                return jsonify({"error": "Invalid start_date format"}), 400
+
+            end_date = None
+            if data.get("end_date"):
+                try:
+                    end_date = datetime.fromisoformat(
+                        data["end_date"].replace("Z", "+00:00")
+                    )
+                except (ValueError, AttributeError):
+                    return jsonify({"error": "Invalid end_date format"}), 400
+
+            # Create recurring expense
+            recurring = RecurringExpense(
+                amount=amount,
+                category=data["category"].strip(),
+                description=data["description"].strip(),
+                frequency=data["frequency"],
+                day_of_month=data.get("day_of_month"),
+                start_date=start_date,
+                end_date=end_date,
+                is_active=data.get("is_active", True),
+            )
+
+            db.session.add(recurring)
+            db.session.commit()
+            logger.info(
+                f"Created recurring expense: {recurring.description} (${amount})"
+            )
+            return jsonify(recurring.to_dict()), 201
+
+        except Exception as e:
+            logger.error(f"Error creating recurring expense: {e}")
+            db.session.rollback()
+            return jsonify({"error": "Server error creating recurring expense"}), 500
+
+    # GET request
+    try:
+        recurring_expenses = RecurringExpense.query.order_by(
+            RecurringExpense.created_at.desc()
+        ).all()
+        return jsonify(
+            {"recurring_expenses": [r.to_dict() for r in recurring_expenses]}
+        )
+    except Exception as e:
+        logger.error(f"Error fetching recurring expenses: {e}")
+        return jsonify({"error": "Server error fetching recurring expenses"}), 500
+
+
+@app.route("/api/recurring/<int:recurring_id>", methods=["GET", "PUT", "DELETE"])
+def handle_recurring_expense(recurring_id):
+    try:
+        recurring = RecurringExpense.query.get_or_404(recurring_id)
+
+        if request.method == "GET":
+            return jsonify(recurring.to_dict())
+
+        elif request.method == "DELETE":
+            db.session.delete(recurring)
+            db.session.commit()
+            logger.info(f"Deleted recurring expense {recurring_id}")
+            return "", 204
+
+        elif request.method == "PUT":
+            data = request.get_json()
+            if data is None:
+                return jsonify({"error": "No JSON data received"}), 400
+
+            # Update fields if provided
+            if "amount" in data:
+                try:
+                    recurring.amount = float(data["amount"])
+                except (ValueError, TypeError):
+                    return jsonify({"error": "Invalid amount value"}), 400
+
+            if "category" in data:
+                recurring.category = data["category"].strip()
+
+            if "description" in data:
+                recurring.description = data["description"].strip()
+
+            if "frequency" in data:
+                if data["frequency"] not in ["monthly", "weekly", "yearly"]:
+                    return jsonify({"error": "Invalid frequency"}), 400
+                recurring.frequency = data["frequency"]
+
+            if "day_of_month" in data:
+                recurring.day_of_month = data["day_of_month"]
+
+            if "start_date" in data:
+                try:
+                    recurring.start_date = datetime.fromisoformat(
+                        data["start_date"].replace("Z", "+00:00")
+                    )
+                except (ValueError, AttributeError):
+                    return jsonify({"error": "Invalid start_date format"}), 400
+
+            if "end_date" in data:
+                if data["end_date"]:
+                    try:
+                        recurring.end_date = datetime.fromisoformat(
+                            data["end_date"].replace("Z", "+00:00")
+                        )
+                    except (ValueError, AttributeError):
+                        return jsonify({"error": "Invalid end_date format"}), 400
+                else:
+                    recurring.end_date = None
+
+            if "is_active" in data:
+                recurring.is_active = bool(data["is_active"])
+
+            db.session.commit()
+            logger.info(f"Updated recurring expense {recurring_id}")
+            return jsonify(recurring.to_dict())
+
+    except Exception as e:
+        logger.error(f"Error handling recurring expense {recurring_id}: {e}")
+        db.session.rollback()
+        return jsonify({"error": "Server error"}), 500
+
+
+@app.route("/api/recurring/apply", methods=["POST"])
+def manually_apply_recurring():
+    """Manually trigger application of due recurring expenses."""
+    try:
+        count = apply_due_recurring_expenses()
+        return jsonify({"success": True, "applied": count})
+    except Exception as e:
+        logger.error(f"Error manually applying recurring expenses: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route("/api/recurring/pending", methods=["GET"])
+def get_pending_recurring():
+    """Preview which recurring expenses would be applied today."""
+    try:
+        today = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        recurring_expenses = (
+            RecurringExpense.query.filter(
+                RecurringExpense.is_active.is_(True),
+                RecurringExpense.start_date <= today,
+            )
+            .filter(
+                (RecurringExpense.end_date.is_(None))
+                | (RecurringExpense.end_date >= today)
+            )
+            .all()
+        )
+
+        pending = []
+        for recurring in recurring_expenses:
+            if is_due_today(recurring, today):
+                # Check for duplicate
+                existing = Expense.query.filter(
+                    Expense.amount == recurring.amount,
+                    Expense.category == recurring.category,
+                    Expense.description == recurring.description,
+                    extract("year", Expense.date) == today.year,
+                    extract("month", Expense.date) == today.month,
+                    extract("day", Expense.date) == today.day,
+                ).first()
+
+                if not existing:
+                    pending.append(recurring.to_dict())
+
+        return jsonify({"pending": pending})
+    except Exception as e:
+        logger.error(f"Error getting pending recurring expenses: {e}")
+        return jsonify({"error": "Server error"}), 500
 
 
 def run_dev_server():

--- a/app.py
+++ b/app.py
@@ -155,13 +155,9 @@ def apply_due_recurring_expenses():
                         db.session.add(expense)
                         recurring.last_applied_date = today
                         applied_count += 1
-                        logger.info(
-                            f"Applied recurring: {recurring.description}"
-                        )
+                        logger.info(f"Applied recurring: {recurring.description}")
                     else:
-                        logger.info(
-                            f"Skipping duplicate: {recurring.description}"
-                        )
+                        logger.info(f"Skipping duplicate: {recurring.description}")
 
             db.session.commit()
             logger.info(f"Applied {applied_count} recurring expenses")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.2
 Flask-SQLAlchemy==3.1.1
 python-dateutil==2.8.2
+APScheduler==3.10.4

--- a/static/components/config.js
+++ b/static/components/config.js
@@ -5,7 +5,10 @@ export const CONFIG = {
         BASE_URL: '/api',
         ENDPOINTS: {
             EXPENSES: '/api/expenses',
-            MONTHS: '/api/months'
+            MONTHS: '/api/months',
+            RECURRING: '/api/recurring',
+            RECURRING_APPLY: '/api/recurring/apply',
+            RECURRING_PENDING: '/api/recurring/pending'
         }
     },
 

--- a/static/components/navbar.js
+++ b/static/components/navbar.js
@@ -38,6 +38,7 @@ class NavBar extends HTMLElement {
         const path = window.location.pathname;
         if (path.includes('add-expense.html')) return 'add-expense';
         if (path.includes('expenses.html')) return 'expenses';
+        if (path.includes('recurring')) return 'recurring';
         return 'home';
     }
 
@@ -96,12 +97,24 @@ class NavBar extends HTMLElement {
             // User liked the big buttons, so maybe keep nav clean or add a small "Add"
             // Let's add "Add" as a primary action for quick access
             actions.push({
+                label: 'Recurring',
+                icon: 'arrow-repeat',
+                href: '/recurring',
+                variant: 'secondary'
+            });
+            actions.push({
                 label: 'Add',
                 icon: 'plus-lg',
                 href: '/static/add-expense.html',
                 variant: 'primary'
             });
         } else if (page === 'expenses') {
+            actions.push({
+                label: 'Recurring',
+                icon: 'arrow-repeat',
+                href: '/recurring',
+                variant: 'secondary'
+            });
             actions.push({
                 label: 'Export',
                 icon: 'download',
@@ -120,6 +133,19 @@ class NavBar extends HTMLElement {
                 icon: 'list-ul',
                 href: '/static/expenses.html',
                 variant: 'secondary'
+            });
+        } else if (page === 'recurring') {
+            actions.push({
+                label: 'Expenses',
+                icon: 'list-ul',
+                href: '/static/expenses.html',
+                variant: 'secondary'
+            });
+            actions.push({
+                label: 'Add',
+                icon: 'plus-lg',
+                href: '/static/add-expense.html',
+                variant: 'primary'
             });
         }
 

--- a/static/components/recurring-list.js
+++ b/static/components/recurring-list.js
@@ -1,0 +1,245 @@
+import { BaseComponent, EventManager } from './event-manager.js';
+import { CONFIG, CategoryHelper, CurrencyHelper } from './config.js';
+import { ApiService } from './api-service.js';
+
+class RecurringList extends BaseComponent {
+    constructor() {
+        super();
+        this.recurringExpenses = [];
+    }
+
+    connectedCallback() {
+        this.render();
+        this.loadRecurringExpenses();
+        this.setupEventListeners();
+    }
+
+    setupEventListeners() {
+        // Listen for recurring expense added/updated/deleted events
+        this.listenToGlobalEvent('recurringadded', () => this.loadRecurringExpenses());
+        this.listenToGlobalEvent('recurringupdated', () => this.loadRecurringExpenses());
+        this.listenToGlobalEvent('recurringdeleted', () => this.loadRecurringExpenses());
+    }
+
+    async loadRecurringExpenses() {
+        try {
+            const response = await fetch(CONFIG.API.ENDPOINTS.RECURRING);
+            if (!response.ok) throw new Error('Failed to load recurring expenses');
+
+            const data = await response.json();
+            this.recurringExpenses = data.recurring_expenses || [];
+            this.render();
+        } catch (error) {
+            console.error('Error loading recurring expenses:', error);
+            window.showToast('Failed to load recurring expenses', 'error');
+        }
+    }
+
+    formatFrequency(recurring) {
+        const freq = recurring.frequency;
+        const day = recurring.day_of_month;
+
+        if (freq === 'monthly' && day) {
+            return `Monthly on day ${day}`;
+        } else if (freq === 'weekly' && day) {
+            const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+            return `Weekly on ${days[day - 1]}`;
+        } else if (freq === 'yearly' && day) {
+            const start = new Date(recurring.start_date);
+            const monthName = start.toLocaleDateString('default', { month: 'long' });
+            return `Yearly on ${monthName} ${day}`;
+        }
+        return freq.charAt(0).toUpperCase() + freq.slice(1);
+    }
+
+    async toggleActive(id, currentStatus) {
+        try {
+            const response = await fetch(`${CONFIG.API.ENDPOINTS.RECURRING}/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ is_active: !currentStatus })
+            });
+
+            if (!response.ok) throw new Error('Failed to update recurring expense');
+
+            window.showToast(`Recurring expense ${!currentStatus ? 'activated' : 'deactivated'}`, 'success');
+            this.loadRecurringExpenses();
+        } catch (error) {
+            console.error('Error toggling recurring expense:', error);
+            window.showToast('Failed to update recurring expense', 'error');
+        }
+    }
+
+    async deleteRecurring(id) {
+        if (!confirm('Are you sure you want to delete this recurring expense?')) return;
+
+        try {
+            const response = await fetch(`${CONFIG.API.ENDPOINTS.RECURRING}/${id}`, {
+                method: 'DELETE'
+            });
+
+            if (!response.ok) throw new Error('Failed to delete recurring expense');
+
+            window.showToast('Recurring expense deleted', 'success');
+            this.loadRecurringExpenses();
+        } catch (error) {
+            console.error('Error deleting recurring expense:', error);
+            window.showToast('Failed to delete recurring expense', 'error');
+        }
+    }
+
+    editRecurring(recurring) {
+        const event = new CustomEvent('show-recurring-form', {
+            detail: { mode: 'edit', recurring }
+        });
+        document.dispatchEvent(event);
+    }
+
+    async applyNow() {
+        try {
+            const response = await fetch(CONFIG.API.ENDPOINTS.RECURRING_APPLY, {
+                method: 'POST'
+            });
+
+            if (!response.ok) throw new Error('Failed to apply recurring expenses');
+
+            const data = await response.json();
+            window.showToast(`Applied ${data.applied} recurring expense(s)`, 'success');
+
+            // Refresh the expense list if we're on the expenses page
+            EventManager.emit('expenseadded');
+        } catch (error) {
+            console.error('Error applying recurring expenses:', error);
+            window.showToast('Failed to apply recurring expenses', 'error');
+        }
+    }
+
+    render() {
+        this.innerHTML = `
+            <div class="card shadow-sm mb-3">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h5 class="card-title mb-0">Active Recurring Expenses</h5>
+                        <button class="btn btn-sm btn-outline-primary" id="apply-now-btn">
+                            <i class="bi bi-lightning-charge"></i> Apply Now
+                        </button>
+                    </div>
+                    <p class="text-muted small mb-0">
+                        <i class="bi bi-info-circle"></i> Expenses are automatically applied daily at midnight
+                    </p>
+                </div>
+            </div>
+
+            ${this.recurringExpenses.length === 0 ? `
+                <div class="text-center py-5 text-muted">
+                    <i class="bi bi-arrow-repeat" style="font-size: 3rem;"></i>
+                    <p class="mt-3">No recurring expenses yet</p>
+                    <p class="small">Click the Add button to create your first recurring expense</p>
+                </div>
+            ` : `
+                <div class="list-group">
+                    ${this.recurringExpenses.map(recurring => this.renderRecurringItem(recurring)).join('')}
+                </div>
+            `}
+        `;
+
+        // Attach event listeners
+        this.attachEventListeners();
+    }
+
+    renderRecurringItem(recurring) {
+        const categoryData = CategoryHelper.getCategoryData(recurring.category);
+        const isActive = recurring.is_active;
+        const hasEndDate = recurring.end_date !== null;
+        const endDateStr = hasEndDate ? new Date(recurring.end_date).toLocaleDateString() : 'No end date';
+
+        return `
+            <div class="list-group-item ${!isActive ? 'opacity-50' : ''}">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div class="flex-grow-1">
+                        <div class="d-flex align-items-center mb-2">
+                            <span class="badge category-${recurring.category} me-2">
+                                <i class="bi bi-${categoryData.icon}"></i>
+                                ${categoryData.label}
+                            </span>
+                            <h6 class="mb-0">${recurring.description}</h6>
+                        </div>
+                        <div class="d-flex align-items-center gap-3 text-muted small">
+                            <span>
+                                <i class="bi bi-cash"></i>
+                                <strong>${CurrencyHelper.format(recurring.amount)}</strong>
+                            </span>
+                            <span>
+                                <i class="bi bi-arrow-repeat"></i>
+                                ${this.formatFrequency(recurring)}
+                            </span>
+                            <span>
+                                <i class="bi bi-calendar"></i>
+                                ${endDateStr}
+                            </span>
+                        </div>
+                        ${recurring.last_applied_date ? `
+                            <div class="text-muted small mt-1">
+                                Last applied: ${new Date(recurring.last_applied_date).toLocaleDateString()}
+                            </div>
+                        ` : ''}
+                    </div>
+                    <div class="d-flex align-items-center gap-2">
+                        <div class="form-check form-switch">
+                            <input
+                                class="form-check-input toggle-active"
+                                type="checkbox"
+                                ${isActive ? 'checked' : ''}
+                                data-id="${recurring.id}"
+                                data-active="${isActive}"
+                                title="${isActive ? 'Deactivate' : 'Activate'}"
+                            >
+                        </div>
+                        <button class="btn btn-sm btn-outline-secondary edit-btn" data-id="${recurring.id}">
+                            <i class="bi bi-pencil"></i>
+                        </button>
+                        <button class="btn btn-sm btn-outline-danger delete-btn" data-id="${recurring.id}">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    attachEventListeners() {
+        // Apply now button
+        const applyBtn = this.querySelector('#apply-now-btn');
+        if (applyBtn) {
+            applyBtn.addEventListener('click', () => this.applyNow());
+        }
+
+        // Toggle switches
+        this.querySelectorAll('.toggle-active').forEach(toggle => {
+            toggle.addEventListener('change', (e) => {
+                const id = e.target.dataset.id;
+                const currentStatus = e.target.dataset.active === 'true';
+                this.toggleActive(id, currentStatus);
+            });
+        });
+
+        // Edit buttons
+        this.querySelectorAll('.edit-btn').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const id = e.target.closest('button').dataset.id;
+                const recurring = this.recurringExpenses.find(r => r.id == id);
+                if (recurring) this.editRecurring(recurring);
+            });
+        });
+
+        // Delete buttons
+        this.querySelectorAll('.delete-btn').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const id = e.target.closest('button').dataset.id;
+                this.deleteRecurring(id);
+            });
+        });
+    }
+}
+
+customElements.define('recurring-list', RecurringList);

--- a/static/recurring.html
+++ b/static/recurring.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Recurring Expenses - Personal Finances</title>
+
+    <!-- Icons -->
+    <link rel="icon" href="/static/pficon.png">
+    <link rel="apple-touch-icon" href="/static/pficon.png">
+    <link rel="manifest" href="/static/site.webmanifest">
+
+    <!-- Mobile Web App -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Recurring">
+    <meta name="application-name" content="Recurring">
+    <meta name="theme-color" content="#007AFF">
+    <meta name="msapplication-TileColor" content="#007AFF">
+    <meta name="msapplication-TileImage" content="/static/pficon.png">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="format-detection" content="telephone=no">
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <!-- Custom Styles -->
+    <link rel="stylesheet" href="/static/styles/theme.css">
+</head>
+
+<body>
+    <nav-bar></nav-bar>
+    <toast-container></toast-container>
+
+    <div class="container py-2">
+        <div class="row justify-content-center">
+            <div class="col-md-10 col-lg-8">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h2 class="mb-0">Recurring Expenses</h2>
+                    <button class="btn btn-primary" id="add-recurring-btn">
+                        <i class="bi bi-plus-lg"></i> Add
+                    </button>
+                </div>
+
+                <recurring-list></recurring-list>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal for adding/editing recurring expenses -->
+    <div class="modal fade" id="recurring-modal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="recurring-modal-title">Add Recurring Expense</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="recurring-form">
+                        <div class="mb-3">
+                            <label for="recurring-amount" class="form-label">Amount</label>
+                            <input type="number" class="form-control" id="recurring-amount" step="0.01" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="recurring-category" class="form-label">Category</label>
+                            <select class="form-select" id="recurring-category" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="recurring-description" class="form-label">Description</label>
+                            <input type="text" class="form-control" id="recurring-description" maxlength="50" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="recurring-frequency" class="form-label">Frequency</label>
+                            <select class="form-select" id="recurring-frequency" required>
+                                <option value="monthly">Monthly</option>
+                                <option value="weekly">Weekly</option>
+                                <option value="yearly">Yearly</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="recurring-day" class="form-label">Day of Month (1-31)</label>
+                            <input type="number" class="form-control" id="recurring-day" min="1" max="31" placeholder="e.g., 1 for 1st of month">
+                        </div>
+                        <div class="mb-3">
+                            <label for="recurring-start-date" class="form-label">Start Date</label>
+                            <input type="date" class="form-control" id="recurring-start-date" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="recurring-end-date" class="form-label">End Date (Optional)</label>
+                            <input type="date" class="form-control" id="recurring-end-date">
+                            <div class="form-text">Leave empty for no end date</div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="recurring-submit-btn">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bootstrap Bundle with Popper -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Core Modules -->
+    <script type="module" src="/static/components/config.js"></script>
+    <script type="module" src="/static/components/api-service.js"></script>
+    <script type="module" src="/static/components/event-manager.js"></script>
+
+    <!-- Custom Components -->
+    <script src="/static/components/navbar.js"></script>
+    <script src="/static/components/toast.js"></script>
+    <script type="module" src="/static/components/recurring-list.js"></script>
+
+    <script>
+        // Dark mode initialization - run immediately
+        (function () {
+            const savedTheme = localStorage.getItem('theme');
+            const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
+
+            document.documentElement.setAttribute('data-bs-theme', theme);
+            localStorage.setItem('theme', theme);
+        })();
+
+        // Dark mode toggle functionality
+        function initDarkMode() {
+            const theme = localStorage.getItem('theme') || 'light';
+            document.documentElement.setAttribute('data-bs-theme', theme);
+        }
+
+        // Initialize dark mode on page load
+        document.addEventListener('DOMContentLoaded', initDarkMode);
+
+        // Modal and form handling
+        let recurringModal;
+        let currentMode = 'create';
+        let currentRecurringId = null;
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            recurringModal = new bootstrap.Modal(document.getElementById('recurring-modal'));
+
+            // Populate categories
+            const { CategoryHelper } = await import('/static/components/config.js');
+            const categorySelect = document.getElementById('recurring-category');
+            CategoryHelper.getAllCategories().forEach(key => {
+                const cat = CategoryHelper.getCategoryData(key);
+                const option = document.createElement('option');
+                option.value = key;
+                option.textContent = cat.label;
+                categorySelect.appendChild(option);
+            });
+
+            // Handle add button
+            document.getElementById('add-recurring-btn').addEventListener('click', () => {
+                currentMode = 'create';
+                currentRecurringId = null;
+                document.getElementById('recurring-modal-title').textContent = 'Add Recurring Expense';
+                document.getElementById('recurring-form').reset();
+                document.getElementById('recurring-start-date').value = new Date().toISOString().split('T')[0];
+                recurringModal.show();
+            });
+
+            // Handle form submission
+            document.getElementById('recurring-submit-btn').addEventListener('click', async (e) => {
+                e.preventDefault();
+
+                const frequency = document.getElementById('recurring-frequency').value;
+                const dayValue = parseInt(document.getElementById('recurring-day').value) || null;
+
+                // Validate day based on frequency
+                if (dayValue !== null) {
+                    if (frequency === 'weekly' && (dayValue < 1 || dayValue > 7)) {
+                        window.showToast('Day of week must be between 1 (Monday) and 7 (Sunday)', 'error');
+                        return;
+                    }
+                    if ((frequency === 'monthly' || frequency === 'yearly') && (dayValue < 1 || dayValue > 31)) {
+                        window.showToast('Day of month must be between 1 and 31', 'error');
+                        return;
+                    }
+                }
+
+                const formData = {
+                    amount: parseFloat(document.getElementById('recurring-amount').value),
+                    category: document.getElementById('recurring-category').value,
+                    description: document.getElementById('recurring-description').value,
+                    frequency: frequency,
+                    day_of_month: dayValue,
+                    start_date: document.getElementById('recurring-start-date').value,
+                    end_date: document.getElementById('recurring-end-date').value || null
+                };
+
+                try {
+                    const url = currentMode === 'create'
+                        ? '/api/recurring'
+                        : `/api/recurring/${currentRecurringId}`;
+                    const method = currentMode === 'create' ? 'POST' : 'PUT';
+
+                    const response = await fetch(url, {
+                        method,
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(formData)
+                    });
+
+                    if (!response.ok) throw new Error('Failed to save');
+
+                    window.showToast(currentMode === 'create' ? 'Recurring expense added!' : 'Recurring expense updated!', 'success');
+                    recurringModal.hide();
+
+                    // Refresh the list
+                    const event = new CustomEvent(currentMode === 'create' ? 'recurringadded' : 'recurringupdated');
+                    document.dispatchEvent(event);
+                } catch (error) {
+                    window.showToast('Error saving recurring expense', 'error');
+                }
+            });
+
+            // Update day field label and max based on frequency
+            document.getElementById('recurring-frequency').addEventListener('change', (e) => {
+                const dayField = document.getElementById('recurring-day');
+                const dayLabel = document.querySelector('label[for="recurring-day"]');
+                if (e.target.value === 'weekly') {
+                    dayLabel.textContent = 'Day of Week (1=Mon, 7=Sun)';
+                    dayField.max = '7';
+                    dayField.placeholder = 'e.g., 1 for Monday';
+                } else {
+                    dayLabel.textContent = 'Day of Month (1-31)';
+                    dayField.max = '31';
+                    dayField.placeholder = 'e.g., 1 for 1st of month';
+                }
+            });
+
+            // Listen for edit events from the list
+            document.addEventListener('show-recurring-form', (e) => {
+                if (e.detail.mode === 'edit' && e.detail.recurring) {
+                    currentMode = 'edit';
+                    const data = e.detail.recurring;
+                    currentRecurringId = data.id;
+
+                    document.getElementById('recurring-modal-title').textContent = 'Edit Recurring Expense';
+                    document.getElementById('recurring-amount').value = data.amount;
+                    document.getElementById('recurring-category').value = data.category;
+                    document.getElementById('recurring-description').value = data.description;
+                    document.getElementById('recurring-frequency').value = data.frequency;
+                    document.getElementById('recurring-day').value = data.day_of_month || '';
+
+                    if (data.start_date) {
+                        document.getElementById('recurring-start-date').value = new Date(data.start_date).toISOString().split('T')[0];
+                    }
+                    if (data.end_date) {
+                        document.getElementById('recurring-end-date').value = new Date(data.end_date).toISOString().split('T')[0];
+                    }
+
+                    recurringModal.show();
+                }
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -1,0 +1,364 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from app import (
+    app,
+    db,
+    RecurringExpense,
+    Expense,
+    apply_due_recurring_expenses,
+    is_due_today,
+)
+
+
+@pytest.fixture
+def client():
+    """Create a test client with a fresh database."""
+    app.config["TESTING"] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+    with app.test_client() as client:
+        with app.app_context():
+            db.create_all()
+            yield client
+            db.session.remove()
+            db.drop_all()
+
+
+def test_create_recurring_expense(client):
+    """Test creating a recurring expense via API."""
+    data = {
+        "amount": 50.0,
+        "category": "super",
+        "description": "Monthly Rent",
+        "frequency": "monthly",
+        "day_of_month": 1,
+        "start_date": datetime.now(timezone.utc).isoformat(),
+    }
+
+    response = client.post("/api/recurring", json=data)
+    assert response.status_code == 201
+
+    json_data = response.get_json()
+    assert json_data["amount"] == 50.0
+    assert json_data["category"] == "super"
+    assert json_data["description"] == "Monthly Rent"
+    assert json_data["frequency"] == "monthly"
+    assert json_data["day_of_month"] == 1
+    assert json_data["is_active"] is True
+
+
+def test_get_recurring_expenses(client):
+    """Test fetching all recurring expenses."""
+    # Create some test data
+    with app.app_context():
+        recurring1 = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Test 1",
+            frequency="monthly",
+            day_of_month=1,
+            start_date=datetime.now(timezone.utc),
+        )
+        recurring2 = RecurringExpense(
+            amount=200.0,
+            category="food_drink",
+            description="Test 2",
+            frequency="weekly",
+            day_of_month=1,
+            start_date=datetime.now(timezone.utc),
+        )
+        db.session.add_all([recurring1, recurring2])
+        db.session.commit()
+
+    response = client.get("/api/recurring")
+    assert response.status_code == 200
+
+    json_data = response.get_json()
+    assert len(json_data["recurring_expenses"]) == 2
+
+
+def test_update_recurring_expense(client):
+    """Test updating a recurring expense."""
+    with app.app_context():
+        recurring = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Test",
+            frequency="monthly",
+            day_of_month=1,
+            start_date=datetime.now(timezone.utc),
+        )
+        db.session.add(recurring)
+        db.session.commit()
+        recurring_id = recurring.id
+
+    update_data = {
+        "amount": 150.0,
+        "description": "Updated Test",
+    }
+
+    response = client.put(f"/api/recurring/{recurring_id}", json=update_data)
+    assert response.status_code == 200
+
+    json_data = response.get_json()
+    assert json_data["amount"] == 150.0
+    assert json_data["description"] == "Updated Test"
+
+
+def test_delete_recurring_expense(client):
+    """Test deleting a recurring expense."""
+    with app.app_context():
+        recurring = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Test",
+            frequency="monthly",
+            day_of_month=1,
+            start_date=datetime.now(timezone.utc),
+        )
+        db.session.add(recurring)
+        db.session.commit()
+        recurring_id = recurring.id
+
+    response = client.delete(f"/api/recurring/{recurring_id}")
+    assert response.status_code == 204
+
+    # Verify it's deleted
+    response = client.get("/api/recurring")
+    json_data = response.get_json()
+    assert len(json_data["recurring_expenses"]) == 0
+
+
+def test_toggle_active(client):
+    """Test toggling the active status of a recurring expense."""
+    with app.app_context():
+        recurring = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Test",
+            frequency="monthly",
+            day_of_month=1,
+            start_date=datetime.now(timezone.utc),
+            is_active=True,
+        )
+        db.session.add(recurring)
+        db.session.commit()
+        recurring_id = recurring.id
+
+    # Deactivate
+    response = client.put(f"/api/recurring/{recurring_id}", json={"is_active": False})
+    assert response.status_code == 200
+    assert response.get_json()["is_active"] is False
+
+    # Reactivate
+    response = client.put(f"/api/recurring/{recurring_id}", json={"is_active": True})
+    assert response.status_code == 200
+    assert response.get_json()["is_active"] is True
+
+
+def test_is_due_today_monthly():
+    """Test monthly frequency due date logic."""
+    today = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+    # Never applied, should be due
+    recurring = RecurringExpense(
+        amount=100.0,
+        category="super",
+        description="Test",
+        frequency="monthly",
+        day_of_month=today.day,
+        start_date=today - timedelta(days=30),
+        last_applied_date=None,
+    )
+    assert is_due_today(recurring, today) is True
+
+    # Applied this month, should not be due
+    recurring.last_applied_date = today
+    assert is_due_today(recurring, today) is False
+
+    # Applied last month, should be due if it's the right day
+    recurring.last_applied_date = today - timedelta(days=31)
+    assert is_due_today(recurring, today) is True
+
+
+def test_is_due_today_weekly():
+    """Test weekly frequency due date logic."""
+    today = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+    # Never applied, should be due on the right weekday
+    recurring = RecurringExpense(
+        amount=100.0,
+        category="super",
+        description="Test",
+        frequency="weekly",
+        day_of_month=today.isoweekday(),  # Today's weekday
+        start_date=today - timedelta(days=7),
+        last_applied_date=None,
+    )
+    assert is_due_today(recurring, today) is True
+
+    # Applied today, should not be due
+    recurring.last_applied_date = today
+    assert is_due_today(recurring, today) is False
+
+    # Applied last week, should be due
+    recurring.last_applied_date = today - timedelta(days=7)
+    assert is_due_today(recurring, today) is True
+
+
+def test_apply_due_recurring_expenses(client):
+    """Test applying due recurring expenses."""
+    with app.app_context():
+        today = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        # Create a due recurring expense
+        recurring = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Monthly Rent",
+            frequency="monthly",
+            day_of_month=today.day,
+            start_date=today - timedelta(days=30),
+            is_active=True,
+            last_applied_date=None,
+        )
+        db.session.add(recurring)
+        db.session.commit()
+
+        # Apply recurring expenses
+        count = apply_due_recurring_expenses()
+        assert count == 1
+
+        # Check that an expense was created
+        expense = Expense.query.filter_by(description="Monthly Rent").first()
+        assert expense is not None
+        assert expense.amount == 100.0
+        assert expense.category == "super"
+
+
+def test_no_duplicate_expenses(client):
+    """Test that duplicate expenses are not created."""
+    with app.app_context():
+        today = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        # Create a recurring expense
+        recurring = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Monthly Rent",
+            frequency="monthly",
+            day_of_month=today.day,
+            start_date=today - timedelta(days=30),
+            is_active=True,
+            last_applied_date=None,
+        )
+        db.session.add(recurring)
+        db.session.commit()
+
+        # Apply once
+        count = apply_due_recurring_expenses()
+        assert count == 1
+
+        # Try to apply again - should not create duplicate
+        count = apply_due_recurring_expenses()
+        assert count == 0
+
+        # Verify only one expense exists
+        expenses = Expense.query.filter_by(description="Monthly Rent").all()
+        assert len(expenses) == 1
+
+
+def test_inactive_recurring_not_applied(client):
+    """Test that inactive recurring expenses are not applied."""
+    with app.app_context():
+        today = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        # Create an inactive recurring expense
+        recurring = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Inactive",
+            frequency="monthly",
+            day_of_month=today.day,
+            start_date=today - timedelta(days=30),
+            is_active=False,
+            last_applied_date=None,
+        )
+        db.session.add(recurring)
+        db.session.commit()
+
+        # Apply recurring expenses
+        count = apply_due_recurring_expenses()
+        assert count == 0
+
+        # Verify no expense was created
+        expense = Expense.query.filter_by(description="Inactive").first()
+        assert expense is None
+
+
+def test_manual_apply_endpoint(client):
+    """Test the manual apply endpoint."""
+    with app.app_context():
+        today = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        # Create a due recurring expense
+        recurring = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Test",
+            frequency="monthly",
+            day_of_month=today.day,
+            start_date=today - timedelta(days=30),
+            is_active=True,
+            last_applied_date=None,
+        )
+        db.session.add(recurring)
+        db.session.commit()
+
+    response = client.post("/api/recurring/apply")
+    assert response.status_code == 200
+
+    json_data = response.get_json()
+    assert json_data["success"] is True
+    assert json_data["applied"] == 1
+
+
+def test_pending_recurring_endpoint(client):
+    """Test the pending recurring expenses endpoint."""
+    with app.app_context():
+        today = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        # Create a due recurring expense
+        recurring = RecurringExpense(
+            amount=100.0,
+            category="super",
+            description="Test",
+            frequency="monthly",
+            day_of_month=today.day,
+            start_date=today - timedelta(days=30),
+            is_active=True,
+            last_applied_date=None,
+        )
+        db.session.add(recurring)
+        db.session.commit()
+
+    response = client.get("/api/recurring/pending")
+    assert response.status_code == 200
+
+    json_data = response.get_json()
+    assert len(json_data["pending"]) == 1
+    assert json_data["pending"][0]["description"] == "Test"


### PR DESCRIPTION
## Summary

- Add `RecurringExpense` model with support for monthly, weekly, and yearly frequencies
- Implement APScheduler to automatically apply due recurring expenses at midnight
- Add CRUD API endpoints for managing recurring expenses (`/api/recurring`)
- Add manual trigger endpoint (`/api/recurring/apply`) and pending preview (`/api/recurring/pending`)
- Create recurring expenses management page with list view and modal form for add/edit
- Add navigation link to recurring page from navbar
- Include comprehensive test suite (12 tests)

## Features

- **Frequency options**: Monthly, weekly, or yearly recurring expenses
- **Day selection**: Specify which day of month (1-31) or day of week (1-7) to apply
- **Active/Inactive toggle**: Easily enable/disable recurring expenses
- **Automatic application**: Scheduler runs daily at midnight to apply due expenses
- **Manual trigger**: "Apply Now" button to immediately apply pending expenses
- **Duplicate prevention**: Won't create duplicate expenses if already applied today

## Test plan

- [x] Run `pytest tests/test_recurring.py` - all 12 tests pass
- [ ] Create a recurring expense via UI
- [ ] Verify it appears in the list
- [ ] Test toggle on/off functionality
- [ ] Test edit and delete buttons
- [ ] Call "Apply Now" and verify expense is created in main list
- [ ] Verify duplicate prevention works