### PR TITLE
feat: bank sync via Enable Banking (BBVA)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Enable Banking (open banking API for BBVA)
+ENABLE_BANKING_APPLICATION_ID=your-app-id-here
+ENABLE_BANKING_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----
+ENABLE_BANKING_ACCOUNT_ID=your-bbva-account-uuid
+ENABLE_BANKING_REDIRECT_URI=https://api.barnola.net/finances/oauth/callback
+ENABLE_BANKING_SANDBOX=false
+
+# Shared secret between cluster-api relay and personal-finances
+# Generate with: openssl rand -hex 32
+INTERNAL_API_KEY=
+
+# Flask
+FLASK_ENV=production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
           if ! sshpass -p "$PI_PASSWORD" ssh -o StrictHostKeyChecking=no $PI_USER@$PI_HOST "cd /home/cesc/personal-finances && \
             git stash && \
             git pull origin main && \
+            python3 scripts/database/migrate_bank_fields.py && \
             sudo systemctl stop personal-finances && \
             sudo systemctl start personal-finances"; then
             echo "::error::Deployment failed - could not update and restart the service"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
     -   id: pytest
         name: pytest
-        entry: pytest
+        entry: venv/bin/pytest
         language: system
         pass_filenames: false
         always_run: true

--- a/app.py
+++ b/app.py
@@ -2,7 +2,9 @@ from flask import Flask, request, jsonify, send_from_directory, redirect, send_f
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime, timezone
 import os
+import json
 import logging
+import functools
 from werkzeug.serving import run_simple
 from sqlalchemy import extract
 from subprocess import run, CalledProcessError
@@ -37,14 +39,23 @@ app.config["TEMPLATES_AUTO_RELOAD"] = True
 db = SQLAlchemy(app)
 
 
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
 class Expense(db.Model):
     __tablename__ = "expense"
 
     id = db.Column(db.Integer, primary_key=True)
     amount = db.Column(db.Float, nullable=False)
     category = db.Column(db.String(50), nullable=False)
-    description = db.Column(db.String(50), nullable=False)
+    description = db.Column(db.String(200), nullable=False)
     date = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    # Bank sync fields (added via migration script on existing DBs)
+    source = db.Column(db.String(20), default="manual")
+    external_id = db.Column(db.String(100), nullable=True, unique=True)
+    merchant = db.Column(db.String(200), nullable=True)
 
     def to_dict(self):
         return {
@@ -53,6 +64,62 @@ class Expense(db.Model):
             "category": self.category,
             "description": self.description,
             "date": self.date.isoformat(),
+            "source": self.source,
+            "external_id": self.external_id,
+            "merchant": self.merchant,
+        }
+
+
+class MerchantMapping(db.Model):
+    __tablename__ = "merchant_mapping"
+
+    id = db.Column(db.Integer, primary_key=True)
+    pattern = db.Column(db.String(200), nullable=False, unique=True)  # e.g. "MERCADONA"
+    category = db.Column(db.String(50), nullable=False)
+    description = db.Column(db.String(200), nullable=False)  # human label
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "pattern": self.pattern,
+            "category": self.category,
+            "description": self.description,
+        }
+
+
+class AppToken(db.Model):
+    __tablename__ = "app_token"
+
+    key = db.Column(db.String(50), primary_key=True)
+    value = db.Column(db.Text, nullable=False)  # JSON blob
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self):
+        return {
+            "key": self.key,
+            "value": json.loads(self.value),
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class SyncLog(db.Model):
+    __tablename__ = "sync_log"
+
+    id = db.Column(db.Integer, primary_key=True)
+    ran_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    status = db.Column(db.String(20))  # ok | error
+    expenses_added = db.Column(db.Integer, default=0)
+    unclassified = db.Column(db.Integer, default=0)
+    error_message = db.Column(db.Text, nullable=True)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "ran_at": self.ran_at.isoformat() if self.ran_at else None,
+            "status": self.status,
+            "expenses_added": self.expenses_added,
+            "unclassified": self.unclassified,
+            "error_message": self.error_message,
         }
 
 
@@ -204,13 +271,54 @@ def is_due_today(recurring, today):
     return False
 
 
-# Initialize scheduler
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+
+def require_internal_key(f):
+    """Decorator: require X-Internal-Key header matching INTERNAL_API_KEY env var."""
+
+    @functools.wraps(f)
+    def decorated(*args, **kwargs):
+        expected = os.environ.get("INTERNAL_API_KEY", "")
+        if not expected:
+            logger.warning("INTERNAL_API_KEY not set — endpoint is unprotected!")
+        provided = request.headers.get("X-Internal-Key", "")
+        if expected and provided != expected:
+            return jsonify({"error": "Unauthorized"}), 401
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+# ---------------------------------------------------------------------------
+# Scheduler
+# ---------------------------------------------------------------------------
+
+
+def _run_bank_sync():
+    """Wrapper so APScheduler can call bank_sync without import-time circular deps."""
+    try:
+        from services.bank_sync import sync_transactions
+
+        sync_transactions()
+    except Exception as e:
+        logger.error(f"Scheduler bank_sync error: {e}", exc_info=True)
+
+
 scheduler = BackgroundScheduler()
 scheduler.add_job(
     apply_due_recurring_expenses, "cron", hour=0, minute=0, id="apply_recurring"
 )
+scheduler.add_job(_run_bank_sync, "interval", hours=6, id="bank_sync")
 scheduler.start()
-logger.info("Scheduler started for recurring expenses")
+logger.info("Scheduler started (recurring @ midnight, bank_sync every 6h)")
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
 
 
 @app.after_request
@@ -239,6 +347,11 @@ def is_test_environment():
     )
 
 
+# ---------------------------------------------------------------------------
+# Page routes
+# ---------------------------------------------------------------------------
+
+
 @app.route("/api/env")
 def get_environment():
     """Return environment info for frontend (e.g., navbar badge)."""
@@ -265,9 +378,24 @@ def serve_recurring():
     return send_from_directory("static", "recurring.html")
 
 
+@app.route("/bank")
+def serve_bank():
+    return send_from_directory("static", "bank.html")
+
+
+@app.route("/unclassified")
+def serve_unclassified():
+    return send_from_directory("static", "unclassified.html")
+
+
 @app.route("/styles.css")
 def serve_css():
     return send_from_directory("static", "styles.css", mimetype="text/css")
+
+
+# ---------------------------------------------------------------------------
+# Expenses API
+# ---------------------------------------------------------------------------
 
 
 @app.route("/api/expenses", methods=["GET", "POST"])
@@ -317,7 +445,6 @@ def handle_expenses():
 
     # GET request
     try:
-        # Get month and year from query parameters, default to current month
         now = datetime.now(timezone.utc)
         month = int(request.args.get("month", now.month))
         year = int(request.args.get("year", now.year))
@@ -354,10 +481,24 @@ def handle_expenses():
         return jsonify({"error": "Server error fetching expenses"}), 500
 
 
+@app.route("/api/expenses/unclassified", methods=["GET"])
+def get_unclassified_expenses():
+    """Expenses imported from bank sync that could not be mapped to a category."""
+    try:
+        expenses = (
+            Expense.query.filter_by(source="bank_sync", category="other")
+            .order_by(Expense.date.desc())
+            .all()
+        )
+        return jsonify({"expenses": [e.to_dict() for e in expenses]})
+    except Exception as e:
+        logger.error(f"Error fetching unclassified expenses: {e}")
+        return jsonify({"error": "Server error"}), 500
+
+
 @app.route("/api/months", methods=["GET"])
 def get_months():
     try:
-        # Get distinct months and years from expenses
         results = (
             db.session.query(
                 extract("year", Expense.date).label("year"),
@@ -367,10 +508,7 @@ def get_months():
             .order_by("year", "month")
             .all()
         )
-
-        # Format results
         months = [{"year": int(r.year), "month": int(r.month)} for r in results]
-
         return jsonify(months)
     except Exception as e:
         logger.error(f"Error fetching months: {e}")
@@ -400,7 +538,6 @@ def update_expense(expense_id):
         if data is None:
             return jsonify({"error": "No JSON data received"}), 400
 
-        # Validate required fields
         required_fields = ["amount", "category", "description"]
         for field in required_fields:
             if field not in data:
@@ -420,7 +557,6 @@ def update_expense(expense_id):
         if not category or not description:
             return jsonify({"error": "Category and description cannot be empty"}), 400
 
-        # Update expense
         expense.amount = amount
         expense.category = category
         expense.description = description
@@ -433,6 +569,11 @@ def update_expense(expense_id):
         logger.error(f"Error updating expense {expense_id}: {e}")
         db.session.rollback()
         return jsonify({"error": "Server error updating expense"}), 500
+
+
+# ---------------------------------------------------------------------------
+# Backup API
+# ---------------------------------------------------------------------------
 
 
 @app.route("/api/backup", methods=["POST"])
@@ -451,7 +592,6 @@ def backup_database():
 
 @app.route("/api/backup/download", methods=["GET"])
 def download_backup():
-    # Run the export script
     try:
         run(
             ["python3", "scripts/database/export_csv.py"],
@@ -461,7 +601,6 @@ def download_backup():
         )
     except CalledProcessError as e:
         return jsonify({"success": False, "error": e.stderr.strip() or str(e)}), 500
-    # Find the most recent CSV file
     export_dir = Path("scripts/database/exports")
     files = sorted(
         glob.glob(str(export_dir / "expenses_*.csv")),
@@ -693,9 +832,171 @@ def get_pending_recurring():
         return jsonify({"error": "Server error"}), 500
 
 
+# ---------------------------------------------------------------------------
+# Bank OAuth + sync API
+# ---------------------------------------------------------------------------
+
+
+@app.route("/api/bank/auth-url", methods=["GET"])
+def bank_auth_url():
+    """Generate and return the Enable Banking OAuth authorization URL."""
+    try:
+        from services.enable_banking import get_auth_url
+
+        url = get_auth_url()
+        return jsonify({"url": url})
+    except Exception as e:
+        logger.error(f"Error generating bank auth URL: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/bank/callback", methods=["POST"])
+@require_internal_key
+def bank_callback():
+    """Receive OAuth code (relayed from cluster-api) and exchange for tokens."""
+    try:
+        data = request.get_json()
+        if not data or "code" not in data:
+            return jsonify({"error": "Missing code"}), 400
+
+        from services.enable_banking import exchange_code
+
+        tokens = exchange_code(data["code"])
+        tokens["last_sync_at"] = None
+
+        record = AppToken.query.get("enable_banking")
+        if record:
+            record.value = json.dumps(tokens)
+            record.updated_at = datetime.now(timezone.utc)
+        else:
+            record = AppToken(key="enable_banking", value=json.dumps(tokens))
+            db.session.add(record)
+
+        db.session.commit()
+        logger.info("bank_callback: tokens stored successfully")
+        return jsonify({"status": "ok"})
+    except Exception as e:
+        logger.error(f"bank_callback error: {e}")
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/bank/sync", methods=["POST"])
+@require_internal_key
+def bank_sync_now():
+    """Manually trigger a bank transaction sync."""
+    try:
+        from services.bank_sync import sync_transactions
+
+        sync_transactions()
+        last_log = SyncLog.query.order_by(SyncLog.ran_at.desc()).first()
+        return jsonify(last_log.to_dict() if last_log else {"status": "ok"})
+    except Exception as e:
+        logger.error(f"bank_sync_now error: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/bank/status", methods=["GET"])
+def bank_status():
+    """Return current token info and last sync time."""
+    try:
+        record = AppToken.query.get("enable_banking")
+        if not record:
+            return jsonify({"connected": False})
+        token_data = json.loads(record.value)
+        last_log = SyncLog.query.order_by(SyncLog.ran_at.desc()).first()
+        return jsonify(
+            {
+                "connected": True,
+                "expires_at": token_data.get("expires_at"),
+                "last_sync_at": token_data.get("last_sync_at"),
+                "updated_at": (
+                    record.updated_at.isoformat() if record.updated_at else None
+                ),
+                "last_log": last_log.to_dict() if last_log else None,
+            }
+        )
+    except Exception as e:
+        logger.error(f"bank_status error: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/bank/logs", methods=["GET"])
+def bank_logs():
+    """Return last 20 SyncLog entries, newest first."""
+    try:
+        logs = SyncLog.query.order_by(SyncLog.ran_at.desc()).limit(20).all()
+        return jsonify({"logs": [log.to_dict() for log in logs]})
+    except Exception as e:
+        logger.error(f"bank_logs error: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+# ---------------------------------------------------------------------------
+# Merchant mappings API
+# ---------------------------------------------------------------------------
+
+
+@app.route("/api/merchants", methods=["GET", "POST"])
+def handle_merchants():
+    if request.method == "POST":
+        try:
+            data = request.get_json()
+            if not data:
+                return jsonify({"error": "No JSON data received"}), 400
+            for field in ("pattern", "category", "description"):
+                if not data.get(field):
+                    return jsonify({"error": f"{field} is required"}), 400
+
+            pattern = data["pattern"].strip().upper()
+            existing = MerchantMapping.query.filter_by(pattern=pattern).first()
+            if existing:
+                existing.category = data["category"].strip()
+                existing.description = data["description"].strip()
+            else:
+                existing = MerchantMapping(
+                    pattern=pattern,
+                    category=data["category"].strip(),
+                    description=data["description"].strip(),
+                )
+                db.session.add(existing)
+
+            db.session.commit()
+            return jsonify(existing.to_dict()), 201
+        except Exception as e:
+            logger.error(f"Error creating merchant mapping: {e}")
+            db.session.rollback()
+            return jsonify({"error": str(e)}), 500
+
+    # GET
+    try:
+        mappings = MerchantMapping.query.order_by(MerchantMapping.pattern).all()
+        return jsonify({"mappings": [m.to_dict() for m in mappings]})
+    except Exception as e:
+        logger.error(f"Error fetching merchant mappings: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/merchants/<int:mapping_id>", methods=["DELETE"])
+def delete_merchant(mapping_id):
+    try:
+        mapping = MerchantMapping.query.get_or_404(mapping_id)
+        db.session.delete(mapping)
+        db.session.commit()
+        return "", 204
+    except Exception as e:
+        logger.error(f"Error deleting merchant mapping {mapping_id}: {e}")
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 500
+
+
+# ---------------------------------------------------------------------------
+# Dev server
+# ---------------------------------------------------------------------------
+
+
 def run_dev_server():
     extra_files = []
-    # Watch static directory for changes
     for root, dirs, files in os.walk("static"):
         for file in files:
             extra_files.append(os.path.join(root, file))

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,12 @@ services:
       - ./data:/app/instance:rw
     environment:
       - FLASK_ENV=production
+      - ENABLE_BANKING_APPLICATION_ID=${ENABLE_BANKING_APPLICATION_ID}
+      - ENABLE_BANKING_PRIVATE_KEY=${ENABLE_BANKING_PRIVATE_KEY}
+      - ENABLE_BANKING_ACCOUNT_ID=${ENABLE_BANKING_ACCOUNT_ID}
+      - ENABLE_BANKING_REDIRECT_URI=${ENABLE_BANKING_REDIRECT_URI}
+      - ENABLE_BANKING_SANDBOX=${ENABLE_BANKING_SANDBOX:-false}
+      - INTERNAL_API_KEY=${INTERNAL_API_KEY}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5001/"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.0.2
 Flask-SQLAlchemy==3.1.1
 python-dateutil==2.8.2
 APScheduler==3.10.4
+requests==2.32.3
+PyJWT==2.9.0

--- a/scripts/database/migrate_bank_fields.py
+++ b/scripts/database/migrate_bank_fields.py
@@ -1,0 +1,41 @@
+"""
+Migration: add bank sync fields to the expense table.
+Run once on the target host before deploying new code.
+"""
+
+import sqlite3
+import os
+
+db_path = os.path.join(os.path.dirname(__file__), "..", "..", "instance", "expenses.db")
+db_path = os.path.normpath(db_path)
+
+print(f"Migrating database: {db_path}")
+conn = sqlite3.connect(db_path)
+c = conn.cursor()
+
+new_columns = [
+    "ALTER TABLE expense ADD COLUMN source VARCHAR(20) DEFAULT 'manual'",
+    "ALTER TABLE expense ADD COLUMN external_id VARCHAR(100)",
+    "ALTER TABLE expense ADD COLUMN merchant VARCHAR(200)",
+]
+
+for stmt in new_columns:
+    col = stmt.split("ADD COLUMN ")[1].split(" ")[0]
+    try:
+        c.execute(stmt)
+        print(f"  Added column: {col}")
+    except sqlite3.OperationalError:
+        print(f"  Column already exists (skipped): {col}")
+
+try:
+    c.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_expense_external_id "
+        "ON expense(external_id)"
+    )
+    print("  Created unique index on expense.external_id")
+except sqlite3.OperationalError as e:
+    print(f"  Index already exists (skipped): {e}")
+
+conn.commit()
+conn.close()
+print("Migration complete.")

--- a/scripts/deployment/personal-finances-test.service
+++ b/scripts/deployment/personal-finances-test.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Personal Finances Flask Application (Test)
+After=network.target
+
+[Service]
+User=cesc
+WorkingDirectory=/home/cesc/personal-finances-test
+Environment="PATH=/home/cesc/personal-finances-test/venv/bin"
+EnvironmentFile=-/home/cesc/personal-finances-test/.env
+ExecStart=/home/cesc/personal-finances-test/venv/bin/python app.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deployment/personal-finances.service
+++ b/scripts/deployment/personal-finances.service
@@ -6,6 +6,7 @@ After=network.target
 User=cesc
 WorkingDirectory=/home/cesc/personal-finances
 Environment="PATH=/home/cesc/personal-finances/venv/bin"
+EnvironmentFile=-/home/cesc/personal-finances/.env
 ExecStart=/home/cesc/personal-finances/venv/bin/python app.py
 Restart=always
 RestartSec=10

--- a/services/bank_sync.py
+++ b/services/bank_sync.py
@@ -1,0 +1,141 @@
+"""
+Bank sync service.
+
+sync_transactions() is called by APScheduler every 6 hours.
+It fetches settled BBVA transactions via Enable Banking, deduplicates them,
+maps merchants to categories, and inserts new Expense rows.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone, timedelta
+
+logger = logging.getLogger(__name__)
+
+
+def sync_transactions():
+    """Fetch new bank transactions and persist them as Expense rows."""
+    # Import here to avoid circular imports at module load time
+    from app import app, db, AppToken, SyncLog, Expense, MerchantMapping
+    from services import enable_banking as eb
+
+    with app.app_context():
+        expenses_added = 0
+        unclassified = 0
+        try:
+            # 1. Load token record
+            token_record = AppToken.query.get("enable_banking")
+            if not token_record:
+                logger.warning("bank_sync: no AppToken for 'enable_banking', skipping")
+                return
+
+            token_data = json.loads(token_record.value)
+
+            # 2. Refresh access token if expiring within 5 minutes
+            expires_at = datetime.fromisoformat(token_data["expires_at"])
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            if expires_at - datetime.now(timezone.utc) < timedelta(minutes=5):
+                logger.info("bank_sync: refreshing access token")
+                new_tokens = eb.refresh_access_token(token_data["refresh_token"])
+                token_data.update(new_tokens)
+                token_record.value = json.dumps(token_data)
+                token_record.updated_at = datetime.now(timezone.utc)
+                db.session.flush()
+
+            # 3. Determine sync window
+            last_sync_raw = token_data.get("last_sync_at")
+            if last_sync_raw:
+                date_from = datetime.fromisoformat(last_sync_raw)
+            else:
+                date_from = datetime.now(timezone.utc) - timedelta(days=30)
+            if date_from.tzinfo is None:
+                date_from = date_from.replace(tzinfo=timezone.utc)
+
+            account_id = __import__("os").environ.get("ENABLE_BANKING_ACCOUNT_ID", "")
+            if not account_id:
+                raise ValueError("ENABLE_BANKING_ACCOUNT_ID env var not set")
+
+            # 4. Fetch transactions
+            transactions = eb.get_transactions(
+                token_data["access_token"], account_id, date_from
+            )
+
+            # 5. Load merchant mappings (case-insensitive substring match)
+            mappings = MerchantMapping.query.all()
+
+            for txn in transactions:
+                ext_id = txn.get("external_id")
+                if not ext_id:
+                    logger.warning(
+                        f"bank_sync: transaction missing external_id, skipping: {txn}"
+                    )
+                    continue
+
+                # Dedup
+                if Expense.query.filter_by(external_id=ext_id).first():
+                    continue
+
+                # Map merchant → category
+                category = "other"
+                description = (
+                    txn.get("merchant") or txn.get("description") or "Bank transaction"
+                )
+                merchant_upper = (txn.get("merchant") or "").upper()
+
+                for mapping in mappings:
+                    if mapping.pattern.upper() in merchant_upper:
+                        category = mapping.category
+                        description = mapping.description
+                        break
+                else:
+                    unclassified += 1
+
+                # Parse transaction date
+                txn_date_raw = txn.get("date")
+                try:
+                    txn_date = datetime.fromisoformat(txn_date_raw).replace(
+                        tzinfo=timezone.utc
+                    )
+                except (TypeError, ValueError):
+                    txn_date = datetime.now(timezone.utc)
+
+                expense = Expense(
+                    amount=txn["amount"],
+                    category=category,
+                    description=description[:200],
+                    date=txn_date,
+                    source="bank_sync",
+                    external_id=ext_id,
+                    merchant=txn.get("merchant", "")[:200],
+                )
+                db.session.add(expense)
+                expenses_added += 1
+
+            # 6. Update last_sync_at
+            token_data["last_sync_at"] = datetime.now(timezone.utc).isoformat()
+            token_record.value = json.dumps(token_data)
+            token_record.updated_at = datetime.now(timezone.utc)
+
+            db.session.add(
+                SyncLog(
+                    status="ok",
+                    expenses_added=expenses_added,
+                    unclassified=unclassified,
+                )
+            )
+            db.session.commit()
+            logger.info(
+                f"bank_sync: added {expenses_added} expenses "
+                f"({unclassified} unclassified)"
+            )
+
+        except Exception as e:
+            logger.error(f"bank_sync error: {e}", exc_info=True)
+            db.session.rollback()
+            try:
+                with app.app_context():
+                    db.session.add(SyncLog(status="error", error_message=str(e)))
+                    db.session.commit()
+            except Exception:
+                pass

--- a/services/enable_banking.py
+++ b/services/enable_banking.py
@@ -1,0 +1,169 @@
+"""
+Enable Banking API client.
+
+Handles JWT generation, OAuth flow, token management, and transaction fetching.
+All communication with the Enable Banking API is done here.
+
+Required environment variables:
+    ENABLE_BANKING_APPLICATION_ID  - from Enable Banking dashboard
+    ENABLE_BANKING_PRIVATE_KEY     - PEM RSA private key content (newlines as \\n)
+    ENABLE_BANKING_REDIRECT_URI    - OAuth callback URL registered in dashboard
+    ENABLE_BANKING_SANDBOX         - "true" for sandbox, "false" for production
+"""
+
+import os
+import time
+import uuid
+import logging
+from datetime import datetime, timezone, timedelta
+
+import jwt
+import requests
+
+logger = logging.getLogger(__name__)
+
+_SANDBOX = os.environ.get("ENABLE_BANKING_SANDBOX", "true").lower() == "true"
+_BASE_URL = "https://api.tilisy.com" if _SANDBOX else "https://api.enablebanking.com"
+_APP_ID = os.environ.get("ENABLE_BANKING_APPLICATION_ID", "")
+_REDIRECT_URI = os.environ.get("ENABLE_BANKING_REDIRECT_URI", "")
+_PRIVATE_KEY_PEM = os.environ.get("ENABLE_BANKING_PRIVATE_KEY", "").replace("\\n", "\n")
+
+
+def _make_jwt() -> str:
+    """Build a short-lived RS256 JWT for Enable Banking request signing."""
+    now = int(time.time())
+    payload = {
+        "iss": _APP_ID,
+        "iat": now,
+        "exp": now + 3600,
+        "jti": str(uuid.uuid4()),
+    }
+    return jwt.encode(payload, _PRIVATE_KEY_PEM, algorithm="RS256")
+
+
+def _headers() -> dict:
+    return {
+        "Authorization": f"Bearer {_make_jwt()}",
+        "Content-Type": "application/json",
+    }
+
+
+def get_auth_url(state: str = "") -> str:
+    """Return the OAuth authorization URL to redirect the user to."""
+    if not state:
+        state = str(uuid.uuid4())
+    params = {
+        "response_type": "code",
+        "client_id": _APP_ID,
+        "redirect_uri": _REDIRECT_URI,
+        "state": state,
+        "scope": "aisp",
+    }
+    param_str = "&".join(f"{k}={v}" for k, v in params.items())
+    return f"{_BASE_URL}/auth?{param_str}"
+
+
+def exchange_code(code: str) -> dict:
+    """Exchange an authorization code for access/refresh tokens.
+
+    Returns dict with keys: access_token, refresh_token, expires_at (ISO string)
+    """
+    resp = requests.post(
+        f"{_BASE_URL}/token",
+        json={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": _REDIRECT_URI,
+        },
+        headers=_headers(),
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        seconds=data.get("expires_in", 3600)
+    )
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data.get("refresh_token", ""),
+        "expires_at": expires_at.isoformat(),
+    }
+
+
+def refresh_access_token(refresh_token: str) -> dict:
+    """Refresh an expired access token.
+
+    Returns dict with keys: access_token, refresh_token, expires_at (ISO string)
+    """
+    resp = requests.post(
+        f"{_BASE_URL}/token",
+        json={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        },
+        headers=_headers(),
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        seconds=data.get("expires_in", 3600)
+    )
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data.get("refresh_token", refresh_token),
+        "expires_at": expires_at.isoformat(),
+    }
+
+
+def get_transactions(access_token: str, account_id: str, date_from: datetime) -> list:
+    """Fetch booked (settled) transactions for a given account since date_from.
+
+    Returns a list of dicts with keys:
+        external_id, amount, currency, date, merchant, description
+    """
+    resp = requests.get(
+        f"{_BASE_URL}/accounts/{account_id}/transactions",
+        params={
+            "date_from": date_from.strftime("%Y-%m-%d"),
+            "status": "booked",
+        },
+        headers={
+            **_headers(),
+            "Authorization": f"Bearer {access_token}",
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    raw = resp.json()
+
+    transactions = []
+    for txn in raw.get("transactions", []):
+        # Normalise fields across different bank formats
+        amount = txn.get("transaction_amount", {})
+        amount_value = abs(float(amount.get("amount", 0)))
+        # Only ingest debits (expenses)
+        if float(amount.get("amount", 0)) >= 0:
+            continue
+
+        merchant = (
+            txn.get("creditor_name")
+            or txn.get("merchant_name")
+            or txn.get("remittance_information_unstructured", "")
+        )
+        transactions.append(
+            {
+                "external_id": txn.get("transaction_id")
+                or txn.get("internal_transaction_id"),
+                "amount": amount_value,
+                "currency": amount.get("currency", "EUR"),
+                "date": txn.get("booking_date") or txn.get("value_date"),
+                "merchant": merchant.strip() if merchant else "",
+                "description": txn.get(
+                    "remittance_information_unstructured", ""
+                ).strip(),
+            }
+        )
+
+    logger.info(f"Fetched {len(transactions)} debit transactions from Enable Banking")
+    return transactions

--- a/static/bank.html
+++ b/static/bank.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Bank Sync - Personal Finances</title>
+
+    <!-- Icons -->
+    <link rel="icon" href="/static/pficon.png">
+    <link rel="apple-touch-icon" href="/static/pficon.png">
+    <link rel="manifest" href="/static/site.webmanifest">
+
+    <!-- Mobile Web App -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Expenses">
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <!-- Custom Styles -->
+    <link rel="stylesheet" href="/static/styles/theme.css">
+</head>
+<body>
+    <nav-bar></nav-bar>
+    <toast-container></toast-container>
+
+    <div class="container py-3">
+        <div class="row justify-content-center">
+            <div class="col-md-10 col-lg-8">
+                <bank-status></bank-status>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bootstrap Bundle with Popper -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Custom Components -->
+    <script src="/static/components/navbar.js"></script>
+    <script src="/static/components/toast.js"></script>
+    <script type="module" src="/static/components/bank-status.js"></script>
+
+    <script>
+        (function() {
+            const savedTheme = localStorage.getItem('theme');
+            const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
+            document.documentElement.setAttribute('data-bs-theme', theme);
+            localStorage.setItem('theme', theme);
+        })();
+        document.addEventListener('DOMContentLoaded', function() {
+            const theme = localStorage.getItem('theme') || 'light';
+            document.documentElement.setAttribute('data-bs-theme', theme);
+        });
+    </script>
+</body>
+</html>

--- a/static/components/bank-status.js
+++ b/static/components/bank-status.js
@@ -1,0 +1,297 @@
+import { BaseComponent } from './event-manager.js';
+import { CurrencyHelper, DateHelper } from './config.js';
+
+class BankStatus extends BaseComponent {
+    connectedCallback() {
+        this.render();
+        this.loadStatus();
+        this.loadLogs();
+        this.loadMerchants();
+    }
+
+    render() {
+        this.innerHTML = `
+            <div>
+                <!-- Connection status card -->
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <div class="d-flex align-items-center justify-content-between mb-3">
+                            <h6 class="fw-bold mb-0">
+                                <i class="bi bi-bank me-2"></i>Bank Connection
+                            </h6>
+                            <span id="connectionBadge" class="badge bg-secondary">Loading…</span>
+                        </div>
+                        <div id="statusDetails" class="text-muted small"></div>
+                        <div class="mt-3 d-flex gap-2 flex-wrap">
+                            <button id="authBtn" class="btn btn-sm btn-outline-primary">
+                                <i class="bi bi-box-arrow-up-right me-1"></i>Authorize Bank
+                            </button>
+                            <button id="syncBtn" class="btn btn-sm btn-primary">
+                                <i class="bi bi-arrow-clockwise me-1"></i>Sync Now
+                            </button>
+                            <a href="/unclassified" class="btn btn-sm btn-outline-warning">
+                                <i class="bi bi-question-circle me-1"></i>Unclassified
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Merchant mappings card -->
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <div class="d-flex align-items-center justify-content-between mb-3">
+                            <h6 class="fw-bold mb-0">
+                                <i class="bi bi-shop me-2"></i>Merchant Mappings
+                            </h6>
+                            <button id="addMerchantBtn" class="btn btn-sm btn-outline-primary">
+                                <i class="bi bi-plus-lg"></i>
+                            </button>
+                        </div>
+                        <!-- Add merchant form (hidden by default) -->
+                        <div id="merchantForm" class="d-none mb-3">
+                            <div class="row g-2">
+                                <div class="col-12 col-sm-4">
+                                    <input id="merchantPattern" type="text" class="form-control form-control-sm"
+                                        placeholder="Pattern (e.g. MERCADONA)">
+                                </div>
+                                <div class="col-12 col-sm-4">
+                                    <select id="merchantCategory" class="form-select form-select-sm">
+                                        <option value="">Category…</option>
+                                    </select>
+                                </div>
+                                <div class="col-12 col-sm-4">
+                                    <input id="merchantDescription" type="text" class="form-control form-control-sm"
+                                        placeholder="Label (e.g. Supermarket)">
+                                </div>
+                                <div class="col-12 d-flex gap-2">
+                                    <button id="saveMerchantBtn" class="btn btn-sm btn-primary">Save</button>
+                                    <button id="cancelMerchantBtn" class="btn btn-sm btn-outline-secondary">Cancel</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="merchantList" class="small"></div>
+                    </div>
+                </div>
+
+                <!-- Sync logs card -->
+                <div class="card">
+                    <div class="card-body">
+                        <h6 class="fw-bold mb-3">
+                            <i class="bi bi-clock-history me-2"></i>Sync History
+                        </h6>
+                        <div id="syncLogs" class="small text-muted">Loading…</div>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        this._populateCategorySelect();
+        this._setupListeners();
+    }
+
+    _populateCategorySelect() {
+        // Dynamically import config to get category list
+        import('./config.js').then(({ CONFIG }) => {
+            const sel = this.querySelector('#merchantCategory');
+            if (!sel) return;
+            Object.entries(CONFIG.CATEGORIES).forEach(([key, cat]) => {
+                const opt = document.createElement('option');
+                opt.value = key;
+                opt.textContent = cat.label;
+                sel.appendChild(opt);
+            });
+        });
+    }
+
+    _setupListeners() {
+        this.querySelector('#authBtn').addEventListener('click', () => this.openAuthUrl());
+        this.querySelector('#syncBtn').addEventListener('click', () => this.triggerSync());
+        this.querySelector('#addMerchantBtn').addEventListener('click', () => {
+            this.querySelector('#merchantForm').classList.toggle('d-none');
+        });
+        this.querySelector('#cancelMerchantBtn').addEventListener('click', () => {
+            this.querySelector('#merchantForm').classList.add('d-none');
+        });
+        this.querySelector('#saveMerchantBtn').addEventListener('click', () => this.saveMerchant());
+    }
+
+    async loadStatus() {
+        try {
+            const res = await fetch('/api/bank/status');
+            const data = await res.json();
+            const badge = this.querySelector('#connectionBadge');
+            const details = this.querySelector('#statusDetails');
+
+            if (data.connected) {
+                badge.className = 'badge bg-success';
+                badge.textContent = 'Connected';
+                const expiresAt = data.expires_at ? new Date(data.expires_at).toLocaleString() : '—';
+                const lastSync = data.last_sync_at ? new Date(data.last_sync_at).toLocaleString() : 'Never';
+                details.innerHTML = `
+                    <div>Token expires: <strong>${expiresAt}</strong></div>
+                    <div>Last sync: <strong>${lastSync}</strong></div>
+                `;
+            } else {
+                badge.className = 'badge bg-danger';
+                badge.textContent = 'Not connected';
+                details.textContent = 'Authorize your bank account to start syncing.';
+            }
+        } catch (e) {
+            console.error('loadStatus error', e);
+        }
+    }
+
+    async loadLogs() {
+        try {
+            const res = await fetch('/api/bank/logs');
+            const data = await res.json();
+            const container = this.querySelector('#syncLogs');
+            if (!data.logs || data.logs.length === 0) {
+                container.textContent = 'No sync history yet.';
+                return;
+            }
+            container.innerHTML = `
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th>Time</th>
+                            <th>Status</th>
+                            <th>Added</th>
+                            <th>Unclassified</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${data.logs.map(log => `
+                            <tr>
+                                <td>${log.ran_at ? new Date(log.ran_at).toLocaleString() : '—'}</td>
+                                <td>
+                                    <span class="badge ${log.status === 'ok' ? 'bg-success' : 'bg-danger'}">
+                                        ${log.status}
+                                    </span>
+                                </td>
+                                <td>${log.expenses_added}</td>
+                                <td>${log.unclassified}</td>
+                            </tr>
+                            ${log.error_message ? `
+                            <tr>
+                                <td colspan="4" class="text-danger small">${log.error_message}</td>
+                            </tr>` : ''}
+                        `).join('')}
+                    </tbody>
+                </table>
+            `;
+        } catch (e) {
+            console.error('loadLogs error', e);
+        }
+    }
+
+    async loadMerchants() {
+        try {
+            const res = await fetch('/api/merchants');
+            const data = await res.json();
+            const container = this.querySelector('#merchantList');
+            if (!data.mappings || data.mappings.length === 0) {
+                container.textContent = 'No mappings yet. Add one to auto-classify transactions.';
+                return;
+            }
+            container.innerHTML = `
+                <ul class="list-group list-group-flush">
+                    ${data.mappings.map(m => `
+                        <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                            <div>
+                                <span class="fw-semibold">${m.pattern}</span>
+                                <span class="text-muted ms-2">→ ${m.category}</span>
+                                <span class="text-muted ms-1">(${m.description})</span>
+                            </div>
+                            <button class="btn btn-sm btn-link text-danger p-0"
+                                data-delete-merchant="${m.id}" aria-label="Delete">
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </li>
+                    `).join('')}
+                </ul>
+            `;
+            container.querySelectorAll('[data-delete-merchant]').forEach(btn => {
+                btn.addEventListener('click', () => this.deleteMerchant(btn.dataset.deleteMerchant));
+            });
+        } catch (e) {
+            console.error('loadMerchants error', e);
+        }
+    }
+
+    async openAuthUrl() {
+        try {
+            const res = await fetch('/api/bank/auth-url');
+            const data = await res.json();
+            if (data.url) {
+                window.open(data.url, '_blank');
+            } else {
+                window.showToast && window.showToast(data.error || 'Failed to get auth URL', 'error');
+            }
+        } catch (e) {
+            window.showToast && window.showToast('Error: ' + e.message, 'error');
+        }
+    }
+
+    async triggerSync() {
+        const btn = this.querySelector('#syncBtn');
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Syncing…';
+        try {
+            const res = await fetch('/api/bank/sync', { method: 'POST' });
+            const data = await res.json();
+            if (data.error) {
+                window.showToast && window.showToast('Sync failed: ' + data.error, 'error');
+            } else {
+                const msg = `Sync complete: ${data.expenses_added ?? 0} added, ${data.unclassified ?? 0} unclassified`;
+                window.showToast && window.showToast(msg, 'success');
+                this.loadStatus();
+                this.loadLogs();
+            }
+        } catch (e) {
+            window.showToast && window.showToast('Sync error: ' + e.message, 'error');
+        } finally {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="bi bi-arrow-clockwise me-1"></i>Sync Now';
+        }
+    }
+
+    async saveMerchant() {
+        const pattern = this.querySelector('#merchantPattern').value.trim();
+        const category = this.querySelector('#merchantCategory').value;
+        const description = this.querySelector('#merchantDescription').value.trim();
+
+        if (!pattern || !category || !description) {
+            window.showToast && window.showToast('All fields are required', 'error');
+            return;
+        }
+
+        try {
+            const res = await fetch('/api/merchants', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ pattern, category, description }),
+            });
+            if (!res.ok) throw new Error(await res.text());
+            this.querySelector('#merchantForm').classList.add('d-none');
+            this.querySelector('#merchantPattern').value = '';
+            this.querySelector('#merchantCategory').value = '';
+            this.querySelector('#merchantDescription').value = '';
+            window.showToast && window.showToast('Mapping saved', 'success');
+            this.loadMerchants();
+        } catch (e) {
+            window.showToast && window.showToast('Error: ' + e.message, 'error');
+        }
+    }
+
+    async deleteMerchant(id) {
+        try {
+            await fetch(`/api/merchants/${id}`, { method: 'DELETE' });
+            this.loadMerchants();
+        } catch (e) {
+            window.showToast && window.showToast('Delete failed', 'error');
+        }
+    }
+}
+
+customElements.define('bank-status', BankStatus);

--- a/static/components/navbar.js
+++ b/static/components/navbar.js
@@ -39,6 +39,8 @@ class NavBar extends HTMLElement {
         if (path.includes('add-expense.html')) return 'add-expense';
         if (path.includes('expenses.html')) return 'expenses';
         if (path.includes('recurring')) return 'recurring';
+        if (path === '/bank') return 'bank';
+        if (path === '/unclassified') return 'unclassified';
         return 'home';
     }
 
@@ -93,9 +95,12 @@ class NavBar extends HTMLElement {
         const actions = [];
 
         if (page === 'home') {
-            // No specific actions for home, maybe just Add?
-            // User liked the big buttons, so maybe keep nav clean or add a small "Add"
-            // Let's add "Add" as a primary action for quick access
+            actions.push({
+                label: 'Bank',
+                icon: 'bank',
+                href: '/bank',
+                variant: 'secondary'
+            });
             actions.push({
                 label: 'Recurring',
                 icon: 'arrow-repeat',
@@ -135,6 +140,19 @@ class NavBar extends HTMLElement {
                 variant: 'secondary'
             });
         } else if (page === 'recurring') {
+            actions.push({
+                label: 'Expenses',
+                icon: 'list-ul',
+                href: '/static/expenses.html',
+                variant: 'secondary'
+            });
+            actions.push({
+                label: 'Add',
+                icon: 'plus-lg',
+                href: '/static/add-expense.html',
+                variant: 'primary'
+            });
+        } else if (page === 'bank' || page === 'unclassified') {
             actions.push({
                 label: 'Expenses',
                 icon: 'list-ul',

--- a/static/components/unclassified-list.js
+++ b/static/components/unclassified-list.js
@@ -1,0 +1,174 @@
+import { BaseComponent } from './event-manager.js';
+import { CONFIG, CurrencyHelper, DateHelper } from './config.js';
+
+class UnclassifiedList extends BaseComponent {
+    connectedCallback() {
+        this.render();
+        this.loadExpenses();
+    }
+
+    render() {
+        this.innerHTML = `
+            <div>
+                <div class="d-flex align-items-center justify-content-between mb-3">
+                    <h6 class="fw-bold mb-0">
+                        <i class="bi bi-question-circle me-2"></i>Unclassified Expenses
+                    </h6>
+                    <a href="/bank" class="btn btn-sm btn-outline-secondary">
+                        <i class="bi bi-bank me-1"></i>Bank Status
+                    </a>
+                </div>
+                <p class="text-muted small">
+                    These transactions were imported from your bank but couldn't be mapped to a category.
+                    Classify them below, or add a merchant mapping on the Bank Status page to auto-classify future transactions.
+                </p>
+                <div id="expenseRows"></div>
+            </div>
+        `;
+    }
+
+    async loadExpenses() {
+        try {
+            const res = await fetch('/api/expenses/unclassified');
+            const data = await res.json();
+            this._renderRows(data.expenses || []);
+        } catch (e) {
+            console.error('loadExpenses error', e);
+            this.querySelector('#expenseRows').textContent = 'Error loading expenses.';
+        }
+    }
+
+    _renderRows(expenses) {
+        const container = this.querySelector('#expenseRows');
+        if (expenses.length === 0) {
+            container.innerHTML = `
+                <div class="text-center text-muted py-4">
+                    <i class="bi bi-check-circle fs-3 d-block mb-2"></i>
+                    All bank transactions are classified.
+                </div>
+            `;
+            return;
+        }
+
+        const categoryOptions = Object.entries(CONFIG.CATEGORIES)
+            .map(([key, cat]) => `<option value="${key}">${cat.label}</option>`)
+            .join('');
+
+        container.innerHTML = expenses.map(expense => `
+            <div class="card mb-2" data-expense-id="${expense.id}">
+                <div class="card-body py-2 px-3">
+                    <div class="d-flex justify-content-between align-items-start mb-2">
+                        <div>
+                            <div class="fw-semibold">${expense.merchant || expense.description}</div>
+                            <div class="text-muted small">
+                                ${new Date(expense.date).toLocaleDateString()}
+                                ${expense.merchant && expense.description !== expense.merchant
+                                    ? '· ' + expense.description
+                                    : ''}
+                            </div>
+                        </div>
+                        <div class="fw-bold">${CurrencyHelper.format(expense.amount)}</div>
+                    </div>
+                    <div class="row g-2">
+                        <div class="col-12 col-sm-5">
+                            <select class="form-select form-select-sm category-select">
+                                <option value="">Select category…</option>
+                                ${categoryOptions}
+                            </select>
+                        </div>
+                        <div class="col-12 col-sm-5">
+                            <input type="text" class="form-control form-control-sm description-input"
+                                placeholder="Description" value="${expense.merchant || expense.description || ''}">
+                        </div>
+                        <div class="col-12 col-sm-2 d-flex gap-1">
+                            <button class="btn btn-sm btn-primary flex-fill save-btn">
+                                Save
+                            </button>
+                        </div>
+                    </div>
+                    <div class="form-check mt-2">
+                        <input class="form-check-input save-mapping-check" type="checkbox" id="saveMapping-${expense.id}">
+                        <label class="form-check-label small text-muted" for="saveMapping-${expense.id}">
+                            Save as merchant mapping
+                        </label>
+                    </div>
+                </div>
+            </div>
+        `).join('');
+
+        container.querySelectorAll('.save-btn').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const card = e.currentTarget.closest('[data-expense-id]');
+                this._saveExpense(card);
+            });
+        });
+    }
+
+    async _saveExpense(card) {
+        const expenseId = card.dataset.expenseId;
+        const category = card.querySelector('.category-select').value;
+        const description = card.querySelector('.description-input').value.trim();
+        const saveMapping = card.querySelector('.save-mapping-check').checked;
+
+        if (!category) {
+            window.showToast && window.showToast('Please select a category', 'error');
+            return;
+        }
+        if (!description) {
+            window.showToast && window.showToast('Please enter a description', 'error');
+            return;
+        }
+
+        // Load current expense data for amount
+        const expenseRes = await fetch(`/api/expenses?page=1&per_page=1000`).catch(() => null);
+
+        try {
+            // Get current expense to preserve amount
+            const listRes = await fetch('/api/expenses/unclassified');
+            const listData = await listRes.json();
+            const expense = listData.expenses.find(e => String(e.id) === String(expenseId));
+            if (!expense) throw new Error('Expense not found');
+
+            const res = await fetch(`/api/expenses/${expenseId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    amount: expense.amount,
+                    category,
+                    description,
+                }),
+            });
+            if (!res.ok) throw new Error(await res.text());
+
+            // Optionally save merchant mapping
+            if (saveMapping && expense.merchant) {
+                await fetch('/api/merchants', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        pattern: expense.merchant.toUpperCase(),
+                        category,
+                        description,
+                    }),
+                });
+            }
+
+            window.showToast && window.showToast('Saved', 'success');
+            card.remove();
+
+            const remaining = this.querySelector('#expenseRows').querySelectorAll('[data-expense-id]');
+            if (remaining.length === 0) {
+                this.querySelector('#expenseRows').innerHTML = `
+                    <div class="text-center text-muted py-4">
+                        <i class="bi bi-check-circle fs-3 d-block mb-2"></i>
+                        All bank transactions are classified.
+                    </div>
+                `;
+            }
+        } catch (e) {
+            window.showToast && window.showToast('Error: ' + e.message, 'error');
+        }
+    }
+}
+
+customElements.define('unclassified-list', UnclassifiedList);

--- a/static/unclassified.html
+++ b/static/unclassified.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Unclassified Expenses - Personal Finances</title>
+
+    <!-- Icons -->
+    <link rel="icon" href="/static/pficon.png">
+    <link rel="apple-touch-icon" href="/static/pficon.png">
+    <link rel="manifest" href="/static/site.webmanifest">
+
+    <!-- Mobile Web App -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Expenses">
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <!-- Custom Styles -->
+    <link rel="stylesheet" href="/static/styles/theme.css">
+</head>
+<body>
+    <nav-bar></nav-bar>
+    <toast-container></toast-container>
+
+    <div class="container py-3">
+        <div class="row justify-content-center">
+            <div class="col-md-10 col-lg-8">
+                <unclassified-list></unclassified-list>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bootstrap Bundle with Popper -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Custom Components -->
+    <script src="/static/components/navbar.js"></script>
+    <script src="/static/components/toast.js"></script>
+    <script type="module" src="/static/components/unclassified-list.js"></script>
+
+    <script>
+        (function() {
+            const savedTheme = localStorage.getItem('theme');
+            const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
+            document.documentElement.setAttribute('data-bs-theme', theme);
+            localStorage.setItem('theme', theme);
+        })();
+        document.addEventListener('DOMContentLoaded', function() {
+            const theme = localStorage.getItem('theme') || 'light';
+            document.documentElement.setAttribute('data-bs-theme', theme);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Enable Banking integration**: OAuth flow, RS256 JWT auth, token refresh, transaction fetching (booked debits only)
- **Auto-sync**: APScheduler job every 6h — deduplicates via `external_id` unique index, maps merchants to categories via `MerchantMapping` table, logs every run to `SyncLog`
- **New models**: `MerchantMapping`, `AppToken`, `SyncLog`; new fields on `Expense` (`source`, `external_id`, `merchant`)
- **New pages**: `/bank` (status panel, merchant mappings, sync logs, manual sync button) and `/unclassified` (classify unknown bank transactions, save as merchant mapping)
- **DB migration**: `scripts/database/migrate_bank_fields.py` — runs automatically on Pi deploy via `deploy.yml`; test env recreates DB on each deploy so no migration needed there
- **Secrets**: service files updated with `EnvironmentFile=` so env vars are picked up from `.env` on each server (never committed)

## Test plan

- [ ] Merge → CI deploys to test VPS
- [ ] Copy `personal-finances-test.service` to `/etc/systemd/system/` on VPS, `daemon-reload`
- [ ] Create `/home/cesc/personal-finances-test/.env` with Enable Banking sandbox credentials
- [ ] `GET /api/bank/auth-url` → open URL → sandbox OAuth flow → callback hits VPS directly
- [ ] `GET /api/bank/status` → confirm token stored
- [ ] `POST /api/bank/sync` → expenses appear with `source=bank_sync`
- [ ] Sync twice → no duplicates
- [ ] Unknown merchant → appears on `/unclassified`
- [ ] Add merchant mapping on `/bank` → re-sync → auto-classified