### PR TITLE
fix: bank sync fixes + app version in navbar

### DIFF
--- a/services/enable_banking.py
+++ b/services/enable_banking.py
@@ -49,7 +49,7 @@ def _headers() -> dict:
 
 
 def get_auth_url(state: str = "") -> str:
-    """Return the OAuth authorization URL to redirect the user to."""
+    """Call Enable Banking /auth API and return the redirect URL for the user."""
     if not state:
         state = str(uuid.uuid4())
     params = {
@@ -59,8 +59,15 @@ def get_auth_url(state: str = "") -> str:
         "state": state,
         "scope": "aisp",
     }
-    param_str = "&".join(f"{k}={v}" for k, v in params.items())
-    return f"{_BASE_URL}/auth?{param_str}"
+    resp = requests.get(
+        f"{_BASE_URL}/auth",
+        params=params,
+        headers=_headers(),
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["url"]
 
 
 def exchange_code(code: str) -> dict:


### PR DESCRIPTION
## Summary
- OAuth callback now accepts GET for direct VPS flow (no relay needed on develop/sandbox)
- Add `cryptography` package to requirements.txt (required by PyJWT for RS256 signing)
- Fix `get_auth_url` to call Enable Banking `/auth` API with JWT instead of building URL statically (browser can't send Authorization header)
- Show git commit hash as app version in navbar (faint monospace label next to brand)

## Test plan
- [ ] `curl http://195.20.230.75:5001/api/bank/auth-url` returns a URL from Enable Banking (not a self-constructed one)
- [ ] Open that URL in browser → BBVA sandbox login completes → callback hits VPS → `Authorization complete` shown
- [ ] `curl http://195.20.230.75:5001/api/bank/status` shows `has_token: true`
- [ ] Navbar shows commit hash next to "Finances" brand