### PR TITLE
fix: load private key from file to avoid systemd backslash stripping

### DIFF
--- a/services/enable_banking.py
+++ b/services/enable_banking.py
@@ -26,7 +26,17 @@ _SANDBOX = os.environ.get("ENABLE_BANKING_SANDBOX", "true").lower() == "true"
 _BASE_URL = "https://api.tilisy.com" if _SANDBOX else "https://api.enablebanking.com"
 _APP_ID = os.environ.get("ENABLE_BANKING_APPLICATION_ID", "")
 _REDIRECT_URI = os.environ.get("ENABLE_BANKING_REDIRECT_URI", "")
-_PRIVATE_KEY_PEM = os.environ.get("ENABLE_BANKING_PRIVATE_KEY", "").replace("\\n", "\n")
+
+
+def _load_private_key() -> str:
+    key_path = os.environ.get("ENABLE_BANKING_PRIVATE_KEY_PATH", "")
+    if key_path:
+        with open(key_path) as f:
+            return f.read()
+    return os.environ.get("ENABLE_BANKING_PRIVATE_KEY", "").replace("\\n", "\n")
+
+
+_PRIVATE_KEY_PEM = _load_private_key()
 
 
 def _make_jwt() -> str:


### PR DESCRIPTION
## Summary
- systemd EnvironmentFile strips backslashes from `\n` sequences, leaving bare `n` chars in the process env — making the PEM key unparseable
- Add `ENABLE_BANKING_PRIVATE_KEY_PATH` env var: if set, the key is read from the file instead
- Fall back to `ENABLE_BANKING_PRIVATE_KEY` env var for backwards compatibility (Pi/production)

## VPS setup after deploy
```bash
# Extract key to file
grep ENABLE_BANKING_PRIVATE_KEY= /home/deployer/personal-finances-test/.env | cut -d= -f2- | sed 's/\\n/\n/g' > /home/deployer/personal-finances-test/private.pem

# Swap env var to file path
sed -i 's|^ENABLE_BANKING_PRIVATE_KEY=.*|ENABLE_BANKING_PRIVATE_KEY_PATH=/home/deployer/personal-finances-test/private.pem|' /home/deployer/personal-finances-test/.env

sudo systemctl restart personal-finances-test
```

## Test plan
- [ ] `curl http://195.20.230.75:5001/api/bank/auth-url` returns a URL from Enable Banking (no 500)
- [ ] Open URL in browser → BBVA sandbox login → callback hits VPS → "Authorization complete"
- [ ] `curl http://195.20.230.75:5001/api/bank/status` shows `has_token: true`