### PR TITLE
fix: add kid header to JWT required by Enable Banking API

### DIFF
--- a/services/enable_banking.py
+++ b/services/enable_banking.py
@@ -48,7 +48,9 @@ def _make_jwt() -> str:
         "exp": now + 3600,
         "jti": str(uuid.uuid4()),
     }
-    return jwt.encode(payload, _PRIVATE_KEY_PEM, algorithm="RS256")
+    return jwt.encode(
+        payload, _PRIVATE_KEY_PEM, algorithm="RS256", headers={"kid": _APP_ID}
+    )
 
 
 def _headers() -> dict:


### PR DESCRIPTION
## Summary
- Enable Banking API requires a `kid` claim in the JWT header — without it the API returns 401 `kid is missing in JWT header`
- Set `kid` to the application ID

## Test plan
- [ ] `curl http://195.20.230.75:5001/api/bank/auth-url` returns a URL (no 500)
- [ ] Open URL in browser → BBVA sandbox login completes → callback hits VPS
- [ ] `curl http://195.20.230.75:5001/api/bank/status` shows `has_token: true`