### PR TITLE
fix: expense list crash, chart legend mobile layout, and route tests

### DIFF
--- a/static/components/category-chart.js
+++ b/static/components/category-chart.js
@@ -324,19 +324,19 @@ class CategoryChart extends HTMLElement {
                 }
                 .chart-body {
                     display: flex;
-                    align-items: center;
+                    flex-direction: column;
                     gap: 1rem;
                 }
                 .donut-container {
-                    flex-shrink: 0;
                     display: flex;
                     justify-content: center;
-                    width: 160px;
-                    height: 160px;
+                    width: 180px;
+                    height: 180px;
+                    margin: 0 auto;
                 }
                 .donut-svg {
-                    width: 160px;
-                    height: 160px;
+                    width: 180px;
+                    height: 180px;
                     filter: drop-shadow(0 2px 8px rgba(0,0,0,0.3));
                 }
                 .donut-segment {
@@ -347,18 +347,15 @@ class CategoryChart extends HTMLElement {
                     filter: brightness(1.15);
                 }
                 .legend-container {
-                    flex: 1;
                     display: flex;
                     flex-direction: column;
-                    gap: 0.25rem;
-                    min-width: 0;
-                    overflow: hidden;
+                    gap: 0.125rem;
+                    width: 100%;
                 }
                 .legend-item {
                     display: flex;
                     align-items: center;
-                    justify-content: space-between;
-                    padding: 0.375rem 0.5rem;
+                    padding: 0.4rem 0.5rem;
                     border-radius: 0.5rem;
                     cursor: pointer;
                     transition: background 0.15s ease;
@@ -368,19 +365,19 @@ class CategoryChart extends HTMLElement {
                     background: var(--surface-container-high);
                 }
                 .legend-item.active {
-                    border-left: 2px solid var(--primary-container);
+                    border-left: 3px solid var(--primary-container);
+                    padding-left: calc(0.5rem - 3px);
                 }
                 .legend-left {
                     display: flex;
                     align-items: center;
-                    gap: 0.375rem;
-                    min-width: 0;
+                    gap: 0.5rem;
                     flex: 1;
-                    overflow: hidden;
+                    min-width: 0;
                 }
                 .legend-icon-dot {
-                    width: 22px;
-                    height: 22px;
+                    width: 24px;
+                    height: 24px;
                     border-radius: 50%;
                     display: flex;
                     align-items: center;
@@ -388,29 +385,32 @@ class CategoryChart extends HTMLElement {
                     flex-shrink: 0;
                 }
                 .legend-label {
-                    font-size: 0.75rem;
+                    font-size: 0.8125rem;
                     color: var(--on-surface);
                     font-weight: 500;
                     white-space: nowrap;
                     overflow: hidden;
                     text-overflow: ellipsis;
+                    min-width: 0;
+                    flex: 1;
                 }
                 .legend-right {
                     display: flex;
                     align-items: center;
-                    gap: 0.375rem;
+                    gap: 0.5rem;
                     flex-shrink: 0;
                 }
                 .legend-amount {
                     font-family: 'Manrope', sans-serif;
                     font-weight: 700;
-                    font-size: 0.75rem;
+                    font-size: 0.8125rem;
                     color: var(--on-surface);
+                    white-space: nowrap;
                 }
                 .legend-pct {
-                    font-size: 0.625rem;
+                    font-size: 0.6875rem;
                     color: var(--outline);
-                    min-width: 24px;
+                    min-width: 28px;
                     text-align: right;
                 }
 

--- a/static/components/latest-expenses.js
+++ b/static/components/latest-expenses.js
@@ -533,7 +533,6 @@ class LatestExpenses extends HTMLElement {
 
             const editBtn = swipeContainer.querySelector('[data-action="edit"]');
             const deleteBtn = swipeContainer.querySelector('[data-action="delete"]');
-            const hintBtn = swipeContainer.querySelector('.swipe-hint-btn');
 
             editBtn.addEventListener('click', (e) => {
                 e.stopPropagation();
@@ -545,20 +544,6 @@ class LatestExpenses extends HTMLElement {
             deleteBtn.addEventListener('click', (e) => {
                 e.stopPropagation();
                 this.confirmDelete(expense, swipeContainer);
-            });
-
-            hintBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                if (this.activeSwipeItem && this.activeSwipeItem !== expenseItem) {
-                    this.activeSwipeItem.classList.remove('swiped');
-                }
-                if (expenseItem.classList.contains('swiped')) {
-                    expenseItem.classList.remove('swiped');
-                    this.activeSwipeItem = null;
-                } else {
-                    expenseItem.classList.add('swiped');
-                    this.activeSwipeItem = expenseItem;
-                }
             });
         });
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -102,12 +102,44 @@ def test_home_page(client):
     """Test home page route"""
     response = client.get("/")
     assert response.status_code == 200
-    assert b"Personal Finance Tracker" in response.data
+    assert b"Vault" in response.data
 
 
 def test_expenses_endpoint(client):
     """Test expenses page route"""
     response = client.get("/expenses")
+    assert response.status_code == 200
+
+
+def test_add_expense_page(client):
+    """Test /add serves the add-expense form page"""
+    response = client.get("/add")
+    assert response.status_code == 200
+    assert b"Vault" in response.data
+
+
+def test_trends_page(client):
+    """Test /trends serves the trends page"""
+    response = client.get("/trends")
+    assert response.status_code == 200
+    assert b"Vault" in response.data
+
+
+def test_recurring_page(client):
+    """Test /recurring page route"""
+    response = client.get("/recurring")
+    assert response.status_code == 200
+
+
+def test_bank_page(client):
+    """Test /bank page route"""
+    response = client.get("/bank")
+    assert response.status_code == 200
+
+
+def test_unclassified_page(client):
+    """Test /unclassified page route"""
+    response = client.get("/unclassified")
     assert response.status_code == 200
 
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,163 @@
+"""
+Browser-based frontend tests using Playwright.
+
+These tests verify that pages load without JS errors and that key components
+render correctly. They catch issues like:
+- JS null-reference crashes (e.g. querying a removed element and calling
+  addEventListener)
+- Components that fail to render at all
+
+Setup (one-time):
+    pip install pytest-playwright
+    playwright install chromium
+
+Run:
+    pytest tests/test_frontend.py -v
+"""
+
+import threading
+import time
+import pytest
+
+# Skip the entire module if playwright is not installed
+pytest.importorskip(
+    "playwright",
+    reason=(
+        "playwright not installed — run: "
+        "pip install pytest-playwright && playwright install chromium"
+    ),
+)
+
+from playwright.sync_api import Page, expect  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def live_server(app_instance):
+    """Start Flask in a background thread so Playwright can hit it."""
+    from werkzeug.serving import make_server
+
+    with app_instance.app_context():
+        from app import db
+
+        db.create_all()
+
+    server = make_server("127.0.0.1", 5099, app_instance)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    time.sleep(0.3)
+    yield "http://127.0.0.1:5099"
+    server.shutdown()
+
+
+@pytest.fixture
+def page_with_errors(page: Page):
+    """Page fixture that collects JS errors for assertion."""
+    errors = []
+    page.on("pageerror", lambda err: errors.append(str(err)))
+    yield page, errors
+
+
+# ---------------------------------------------------------------------------
+# Home page
+# ---------------------------------------------------------------------------
+
+
+def test_home_no_js_errors(page_with_errors, live_server):
+    """Home page must load without any JavaScript exceptions."""
+    page, errors = page_with_errors
+    page.goto(live_server + "/")
+    page.wait_for_load_state("networkidle")
+    assert errors == [], f"JS errors on /: {errors}"
+
+
+def test_home_expense_list_renders(page_with_errors, live_server):
+    """latest-expenses component must be present and not error-state."""
+    page, errors = page_with_errors
+    page.goto(live_server + "/")
+    page.wait_for_load_state("networkidle")
+    assert errors == [], f"JS errors on /: {errors}"
+    # The web component must exist in the DOM
+    assert page.locator("latest-expenses").count() > 0
+
+
+# ---------------------------------------------------------------------------
+# Expenses page (expense-list + category-chart)
+# ---------------------------------------------------------------------------
+
+
+def test_expenses_no_js_errors(page_with_errors, live_server):
+    """Expenses page must load without any JavaScript exceptions."""
+    page, errors = page_with_errors
+    page.goto(live_server + "/expenses")
+    page.wait_for_load_state("networkidle")
+    assert errors == [], f"JS errors on /expenses: {errors}"
+
+
+def test_expenses_list_card_renders(page_with_errors, live_server):
+    """expense-list component must render its card wrapper."""
+    page, errors = page_with_errors
+    page.goto(live_server + "/expenses")
+    page.wait_for_load_state("networkidle")
+    assert errors == [], f"JS errors on /expenses: {errors}"
+    expect(page.locator(".expense-list-card")).to_be_visible()
+
+
+def test_category_chart_renders(page_with_errors, live_server):
+    """category-chart component must render its chart wrapper."""
+    page, errors = page_with_errors
+    page.goto(live_server + "/expenses")
+    page.wait_for_load_state("networkidle")
+    assert errors == [], f"JS errors on /expenses: {errors}"
+    expect(page.locator(".chart-wrapper")).to_be_visible()
+
+
+def test_expense_item_swipe_no_crash(page_with_errors, live_server, client):
+    """
+    Swipe setup must not crash even when no swipe-hint-btn exists.
+    Regression test for:
+    TypeError: Cannot read properties of null (reading 'addEventListener')
+    """
+    # Add a test expense so the list renders actual items
+    client.post(
+        "/api/expenses",
+        json={
+            "amount": 42.0,
+            "category": "other",
+            "description": "Playwright test expense",
+        },
+    )
+    page, errors = page_with_errors
+    page.goto(live_server + "/")
+    page.wait_for_load_state("networkidle")
+    assert errors == [], f"JS crash setting up swipe handlers: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Add expense page
+# ---------------------------------------------------------------------------
+
+
+def test_add_expense_no_js_errors(page_with_errors, live_server):
+    """Add expense page must load without any JavaScript exceptions."""
+    page, errors = page_with_errors
+    page.goto(live_server + "/add")
+    page.wait_for_load_state("networkidle")
+    assert errors == [], f"JS errors on /add: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Trends page
+# ---------------------------------------------------------------------------
+
+
+def test_trends_no_js_errors(page_with_errors, live_server):
+    """Trends page must load without any JavaScript exceptions."""
+    page, errors = page_with_errors
+    page.goto(live_server + "/trends")
+    page.wait_for_load_state("networkidle")
+    assert errors == [], f"JS errors on /trends: {errors}"


### PR DESCRIPTION
## Summary
- **Fix JS crash**: `hintBtn.addEventListener` was called on `null` — the `swipe-hint-btn` element was removed from the HTML template in a previous PR but its JS setup code remained, crashing every time the expense list loaded
- **Fix category chart legend**: switched from side-by-side layout (160px donut + narrow legend leaving <50px for label text) to vertical layout (180px donut centered, full-width legend below) — all category names are now fully readable on mobile
- **Fix expense list item**: compact date ("Today", "Yesterday", "18 Mar" — no time), removed redundant category label from meta row
- **Fix test regression**: `test_home_page` was asserting `"Personal Finance Tracker"` but the title changed to `"Vault"` — now fixed
- **Add route tests**: `/add`, `/trends`, `/recurring`, `/bank`, `/unclassified` all covered
- **Add Playwright smoke tests**: `test_frontend.py` checks each page loads with zero JS console errors; includes explicit regression test for the null `hintBtn` crash; auto-skips if Playwright not installed

## Test plan
- [ ] Open home page on mobile — expense list items show "Today · MANUAL" (no wrapping)
- [ ] Open expenses page — chart legend shows full category names below the donut
- [ ] Open expenses page — no "Failed to load expenses" error
- [ ] Run `pytest` — all tests pass