### PR TITLE
chore: add .dockyard.json configuration

### DIFF
--- a/.dockyard.json
+++ b/.dockyard.json
@@ -1,0 +1,4 @@
+{
+  "start": "python app.py",
+  "port": 5001
+}


### PR DESCRIPTION
## Summary
* Adds `.dockyard.json` with standard generic settings to configure the Dockyard/Factoryfloor app runner.
* Specifies `python app.py` as the startup command.
* Defines `5001` as the default port.