### PR TITLE
feat: recurring fix, PWA nav, trends page overhaul + Top Spends

### DIFF
--- a/.dockyard.json
+++ b/.dockyard.json
@@ -1,0 +1,4 @@
+{
+  "start": "python app.py",
+  "port": 5001
+}

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, jsonify, send_from_directory, send_file
 from flask_sqlalchemy import SQLAlchemy
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+
 import os
 import json
 import logging
@@ -207,9 +208,7 @@ def apply_due_recurring_expenses():
     """Apply recurring expenses that are due today."""
     with app.app_context():
         try:
-            today = datetime.now(timezone.utc).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
+            today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
             logger.info(f"Checking for due recurring expenses on {today.date()}")
 
             # Query active recurring expenses
@@ -228,14 +227,14 @@ def apply_due_recurring_expenses():
             applied_count = 0
             for recurring in recurring_expenses:
                 if is_due_today(recurring, today):
-                    # Check for duplicate
+                    # Date-range dedup: reliable with SQLite naive datetime strings
+                    next_day = today + timedelta(days=1)
                     existing = Expense.query.filter(
                         Expense.amount == recurring.amount,
                         Expense.category == recurring.category,
                         Expense.description == recurring.description,
-                        extract("year", Expense.date) == today.year,
-                        extract("month", Expense.date) == today.month,
-                        extract("day", Expense.date) == today.day,
+                        Expense.date >= today,
+                        Expense.date < next_day,
                     ).first()
 
                     if not existing:
@@ -264,14 +263,18 @@ def apply_due_recurring_expenses():
 
 
 def is_due_today(recurring, today):
-    """Check if a recurring expense is due today."""
-    # If never applied, check if start_date is today or earlier
-    if recurring.last_applied_date is None:
-        return True
+    """Check if a recurring expense is due today.
 
-    last_applied = recurring.last_applied_date.replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
+    `today` must be a naive datetime with time zeroed to midnight.
+    """
+    if recurring.last_applied_date is None:
+        # Far-past sentinel: let the frequency checks decide based on due day,
+        # instead of firing unconditionally on first boot.
+        last_applied = today.replace(year=2000, month=1, day=1)
+    else:
+        last_applied = recurring.last_applied_date.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
 
     if recurring.frequency == "monthly":
         # Due if it's the specified day of month and not applied this month

--- a/app.py
+++ b/app.py
@@ -584,65 +584,63 @@ def get_categories():
 @app.route("/api/trends", methods=["GET"])
 def get_trends():
     try:
-        from datetime import datetime, timedelta
+        import calendar
         from sqlalchemy import func
 
         now = datetime.now()
 
-        # Calculate monthly totals for the last 4 months
+        def period_data(start, end, include_top=False):
+            cat_rows = (
+                db.session.query(Expense.category, func.sum(Expense.amount))
+                .filter(Expense.date >= start, Expense.date <= end)
+                .group_by(Expense.category)
+                .all()
+            )
+            categories = {cat: float(total) for cat, total in cat_rows}
+            total = sum(categories.values())
+            result = {"total": total, "categories": categories}
+            if include_top:
+                top = (
+                    db.session.query(Expense)
+                    .filter(Expense.date >= start, Expense.date <= end)
+                    .order_by(Expense.amount.desc())
+                    .limit(5)
+                    .all()
+                )
+                result["top_expenses"] = [
+                    {
+                        "amount": float(e.amount),
+                        "category": e.category,
+                        "description": e.description,
+                        "date": e.date.strftime("%Y-%m-%d"),
+                    }
+                    for e in top
+                ]
+            return result
+
         monthly_data = []
         for i in range(4):
-            # Calculate the month and year for i months ago
             target_month = now.month - i
             target_year = now.year
             if target_month <= 0:
                 target_month += 12
                 target_year -= 1
+            label = f"{target_month:02d}/{str(target_year)[-2:]}"
+            last_day = calendar.monthrange(target_year, target_month)[1]
+            start_str = f"{target_year}-{target_month:02d}-01 00:00:00"
+            end_str = f"{target_year}-{target_month:02d}-{last_day:02d} 23:59:59"
+            data = period_data(start_str, end_str, include_top=(i == 0))
+            monthly_data.insert(0, {"label": label, **data})
 
-            target_month_str = f"{target_year}-{target_month:02d}"
-
-            total = (
-                db.session.query(func.sum(Expense.amount))
-                .filter(func.strftime("%Y-%m", Expense.date) == target_month_str)
-                .scalar()
-                or 0.0
-            )
-
-            monthly_data.insert(
-                0,
-                {
-                    "label": f"{target_month:02d}/{str(target_year)[-2:]}",
-                    "total": float(total),
-                },
-            )
-
-        # Calculate weekly totals for the last 4 weeks (rolling 7-day windows)
         weekly_data = []
+        labels = ["This Week", "Last Week", "2 Weeks Ago", "3 Weeks Ago"]
         for i in range(4):
             end_date = now - timedelta(days=i * 7)
             start_date = end_date - timedelta(days=6)
-
-            # Format label
-            if i == 0:
-                label = "This Week"
-            elif i == 1:
-                label = "Last Week"
-            else:
-                label = f"{i} Weeks Ago"
-
-            # SQLite datetime comparison
-            # Need to format dates to match SQLite storage string format (YYYY-MM-DD)
             start_str = start_date.strftime("%Y-%m-%d 00:00:00")
             end_str = end_date.strftime("%Y-%m-%d 23:59:59")
-
-            total = (
-                db.session.query(func.sum(Expense.amount))
-                .filter(Expense.date >= start_str, Expense.date <= end_str)
-                .scalar()
-                or 0.0
-            )
-
-            weekly_data.insert(0, {"label": label, "total": float(total)})
+            data = period_data(start_str, end_str, include_top=(i == 0))
+            weekly_data.insert(0, {"label": labels[i], **data})
 
         return jsonify({"weekly": weekly_data, "monthly": monthly_data})
     except Exception as e:

--- a/docs/superpowers/specs/2026-06-09-trends-fixes-and-top-spends-design.md
+++ b/docs/superpowers/specs/2026-06-09-trends-fixes-and-top-spends-design.md
@@ -1,0 +1,123 @@
+# Trends Page: Bug Fixes + Top Spends Feature
+
+## Overview
+
+Fix three broken features on the trends page (category velocity, smart alert, weekly daily-avg) and add a new Top Spends section showing the biggest individual expenses in the current period.
+
+## Backend: Extended `/api/trends` Response
+
+**File:** `app.py` — `get_trends()` function
+
+### New response shape
+
+Each period object gains a `categories` dict. The current period (last element, index 3) also gets a `top_expenses` list.
+
+```json
+{
+  "weekly": [
+    {
+      "label": "3 Weeks Ago",
+      "total": 620.37,
+      "categories": {"food_drink": 120.0, "transport": 45.0}
+    },
+    { "label": "2 Weeks Ago", "total": 800.08, "categories": {...} },
+    { "label": "Last Week",   "total": 588.21, "categories": {...} },
+    {
+      "label": "This Week",
+      "total": 2154.04,
+      "categories": {...},
+      "top_expenses": [
+        {"amount": 200.0, "category": "shopping", "description": "IKEA", "date": "2026-06-07"},
+        {"amount": 150.0, "category": "health",   "description": "Gym", "date": "2026-06-05"}
+      ]
+    }
+  ],
+  "monthly": [ ...same structure... ]
+}
+```
+
+### Implementation
+
+For each period (weekly and monthly):
+- Replace the scalar `func.sum()` query with a `GROUP BY category` query to build the `categories` dict.
+- Keep computing `total` as the sum of all category values.
+
+For the current period only (i=0 in each loop, which ends up at index 3 after `insert(0, ...)`):
+- Run an additional `ORDER BY amount DESC LIMIT 5` query to get `top_expenses`.
+- Each top expense includes: `amount` (float), `category` (str), `description` (str), `date` (YYYY-MM-DD string).
+
+Total queries: 4 (weekly) + 4 (monthly) period queries + 2 top-expense queries = 10. Acceptable for SQLite on a personal app.
+
+## Frontend: Bug Fixes
+
+**File:** `static/components/spending-trends.js`
+
+### Fix 1 — Category Velocity
+
+`computeWeekly()` and `computeMonthly()` currently set `expenses: []` on each period. Replace this with `categories: period.categories || {}` from the server data.
+
+`computeCategoryVelocity()` currently iterates `current.expenses` and `prev.expenses` arrays (always empty). Replace with direct access to `current.categories` and `prev.categories` dicts:
+
+```js
+const cur = current.categories[cat] || 0;
+const pre = prev.categories[cat] || 0;
+```
+
+### Fix 2 — Smart Alert
+
+`renderSmartAlert()` guards on `this.expenses.length < 5` — `this.expenses` is a class property initialized to `[]` and never populated. Replace the guard with a check on actual period data:
+
+```js
+if (this.periods.length < 2 || this.periods[this.periods.length - 1].total === 0) {
+    alertEl.style.display = 'none';
+    return;
+}
+```
+
+### Fix 3 — Weekly Daily Avg
+
+The backend "current week" is a rolling 7-day window ending today. `daysSoFar` uses `new Date().getDay()` (calendar weekday since Sunday), which is wrong for a rolling window.
+
+Fix: in weekly mode, `daysSoFar = 7` and `daysInPeriod = 7`. This gives an accurate daily average over the 7-day rolling window, and a meaningful projected total.
+
+## Frontend: New Top Spends Section
+
+**File:** `static/components/spending-trends.js`
+
+### Placement
+
+New section added to the HTML template below `#categoryVelocity`, before `#smartAlert`.
+
+### Data source
+
+Reads `this.serverData.weekly[3].top_expenses` or `this.serverData.monthly[3].top_expenses` depending on `this.mode`. No extra API call — data is embedded in the existing trends response.
+
+Re-renders automatically when the weekly/monthly toggle switches (called from `renderTrends()`).
+
+### Layout
+
+Section title: "Top Spends" (same uppercase small-caps style as "Category Velocity").
+
+Each row (`#topSpends` container):
+- Left: category icon circle (colored, matching existing category palette via `CategoryHelper`)
+- Center: description (truncated ~30 chars) + date formatted as "Jun 7"
+- Right: amount (right-aligned, prominent Manrope font)
+
+Reuses `.velocity-card` and `.velocity-left/.velocity-right` CSS classes for visual consistency.
+
+Fallback: if `top_expenses` is empty or missing, show the same "Not enough data" placeholder used by Category Velocity.
+
+### New method
+
+`renderTopSpends()` — reads the top expenses for the current mode, builds the HTML, injects into `#topSpends`. Called at the end of `renderTrends()`.
+
+## Error Handling
+
+No change to existing error handling. The `top_expenses` field defaults to `[]` if the query returns nothing. Frontend guards against missing/empty arrays with the fallback placeholder.
+
+## Testing
+
+- Seed DB with expenses across multiple months/weeks, verify category velocity cards render with correct delta %
+- Verify smart alert appears when spending difference > 5% or > 10%
+- Verify weekly daily avg = (current week total) / 7 on any day of the week
+- Verify top spends list shows correct 5 entries, sorted by amount descending, updating on toggle

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+testpaths = tests

--- a/static/add-expense.html
+++ b/static/add-expense.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1777669514">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
 <style>#submitBtn { position: relative; z-index: 9999; pointer-events: auto !important; }</style>
 </head>
 <body>
@@ -74,15 +74,15 @@
     </div>
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778016442"></script>
-    <script type="module" src="/static/components/api-service.js?v=1778016442"></script>
-    <script type="module" src="/static/components/event-manager.js?v=1778016442"></script>
+    <script type="module" src="/static/components/config.js?v=1778100000"></script>
+    <script type="module" src="/static/components/api-service.js?v=1778100000"></script>
+    <script type="module" src="/static/components/event-manager.js?v=1778100000"></script>
 
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778016442"></script>
-    <script type="module" src="/static/components/toast.js?v=1778016442"></script>
-    <script type="module" src="/static/components/add-expense-form.js?v=1778016442"></script>
+    <script src="/static/components/navbar.js?v=1778100000"></script>
+    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
+    <script type="module" src="/static/components/add-expense-form.js?v=1778100000"></script>
 
-    
+
 </body>
 </html>

--- a/static/components/spending-trends.js
+++ b/static/components/spending-trends.js
@@ -48,7 +48,7 @@ class SpendingTrends extends BaseComponent {
             if (chartContainer) {
                 chartContainer.innerHTML = '<div class="text-center py-5"><div class="spinner-border" role="status"></div></div>';
             }
-            
+
             // Fetch aggregated data directly from backend instead of calculating on client
             this.serverData = await ApiService.getTrends();
             this.computeTrends();
@@ -68,29 +68,29 @@ class SpendingTrends extends BaseComponent {
 
     computeWeekly() {
         if (!this.serverData || !this.serverData.weekly) return;
-        
-        const periods = this.serverData.weekly.map((week, index) => ({
+
+        this.periods = this.serverData.weekly.map((week, index) => ({
             label: index === 3 ? 'CURRENT' : week.label,
             total: week.total,
             isCurrent: index === 3,
-            expenses: []
+            categories: week.categories || {},
+            top_expenses: week.top_expenses || [],
         }));
-        
-        this.periods = periods;
+
         this.renderTrends();
     }
 
     computeMonthly() {
         if (!this.serverData || !this.serverData.monthly) return;
-        
-        const periods = this.serverData.monthly.map((month, index) => ({
+
+        this.periods = this.serverData.monthly.map((month, index) => ({
             label: index === 3 ? 'CURRENT' : month.label,
             total: month.total,
             isCurrent: index === 3,
-            expenses: []
+            categories: month.categories || {},
+            top_expenses: month.top_expenses || [],
         }));
-        
-        this.periods = periods;
+
         this.renderTrends();
     }
 
@@ -110,10 +110,10 @@ class SpendingTrends extends BaseComponent {
 
         // Compute daily avg and projected
         const currentPeriod = this.periods.find(p => p.isCurrent);
-        const daysInPeriod = this.mode === 'weekly' ? 7 : new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0).getDate();
-        const daysSoFar = this.mode === 'weekly'
-            ? Math.min(new Date().getDay() || 7, 7)
-            : new Date().getDate();
+        const daysInPeriod = this.mode === 'weekly'
+            ? 7
+            : new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0).getDate();
+        const daysSoFar = this.mode === 'weekly' ? 7 : new Date().getDate();
         const dailyAvg = daysSoFar > 0 ? currentTotal / daysSoFar : 0;
         const projected = dailyAvg * daysInPeriod;
 
@@ -177,6 +177,9 @@ class SpendingTrends extends BaseComponent {
 
         // Smart alert
         this.renderSmartAlert();
+
+        // Top spends
+        this.renderTopSpends();
     }
 
     computeCategoryVelocity() {
@@ -185,26 +188,21 @@ class SpendingTrends extends BaseComponent {
         const current = this.periods[this.periods.length - 1];
         const prev = this.periods[this.periods.length - 2];
 
-        const currentByCategory = {};
-        const prevByCategory = {};
+        const currentByCategory = current.categories || {};
+        const prevByCategory = prev.categories || {};
 
-        current.expenses.forEach(exp => {
-            currentByCategory[exp.category] = (currentByCategory[exp.category] || 0) + parseFloat(exp.amount);
-        });
-        prev.expenses.forEach(exp => {
-            prevByCategory[exp.category] = (prevByCategory[exp.category] || 0) + parseFloat(exp.amount);
-        });
+        const allCats = new Set([
+            ...Object.keys(currentByCategory),
+            ...Object.keys(prevByCategory),
+        ]);
 
-        const allCats = new Set([...Object.keys(currentByCategory), ...Object.keys(prevByCategory)]);
         const results = [];
-
         allCats.forEach(cat => {
             const cur = currentByCategory[cat] || 0;
             const pre = prevByCategory[cat] || 0;
             if (cur === 0 && pre === 0) return;
 
             const delta = pre > 0 ? ((cur - pre) / pre) * 100 : (cur > 0 ? 100 : 0);
-
             results.push({
                 category: cat,
                 label: CategoryHelper.getCategoryLabel(cat),
@@ -212,16 +210,18 @@ class SpendingTrends extends BaseComponent {
                 color: CategoryHelper.getCategoryColor(cat),
                 current: cur,
                 previous: pre,
-                delta
+                delta,
             });
         });
 
-        return results.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta)).slice(0, 5);
+        return results
+            .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+            .slice(0, 5);
     }
 
     renderSmartAlert() {
         const alertEl = this.querySelector('#smartAlert');
-        if (this.periods.length < 2 || this.expenses.length < 5) {
+        if (this.periods.length < 2 || this.periods[this.periods.length - 1].total === 0) {
             alertEl.style.display = 'none';
             return;
         }
@@ -246,6 +246,52 @@ class SpendingTrends extends BaseComponent {
 
         alertEl.style.display = 'block';
         this.querySelector('#smartAlertText').textContent = message;
+    }
+
+    renderTopSpends() {
+        const el = this.querySelector('#topSpends');
+        if (!el) return;
+
+        const currentPeriod = this.periods.find(p => p.isCurrent);
+        const top = (currentPeriod && currentPeriod.top_expenses) || [];
+
+        if (top.length === 0) {
+            el.innerHTML = `
+                <div style="text-align: center; padding: 1.5rem; color: var(--outline); font-size: 0.8125rem;">
+                    Not enough data to show top spends
+                </div>
+            `;
+            return;
+        }
+
+        el.innerHTML = top.map(exp => {
+            const icon = CategoryHelper.getCategoryIcon(exp.category);
+            const color = CategoryHelper.getCategoryColor(exp.category);
+            const desc = exp.description.length > 28
+                ? exp.description.slice(0, 28) + '…'
+                : exp.description;
+            const date = new Date(exp.date + 'T00:00:00');
+            const dateStr = date.toLocaleDateString('default', { month: 'short', day: 'numeric' });
+
+            return `
+                <div class="velocity-card">
+                    <div class="velocity-left">
+                        <div class="velocity-icon" style="color: ${color};">
+                            <span class="material-symbols-outlined">${icon}</span>
+                        </div>
+                        <div>
+                            <div class="velocity-name">${desc}</div>
+                            <div class="velocity-sub">${dateStr}</div>
+                        </div>
+                    </div>
+                    <div class="velocity-right">
+                        <div class="velocity-delta" style="color: var(--on-surface);">
+                            ${CurrencyHelper.format(exp.amount)}
+                        </div>
+                    </div>
+                </div>
+            `;
+        }).join('');
     }
 
     render() {
@@ -555,6 +601,10 @@ class SpendingTrends extends BaseComponent {
             <!-- Category Velocity -->
             <div class="velocity-section-title">Category Velocity</div>
             <div id="categoryVelocity"></div>
+
+            <!-- Top Spends -->
+            <div class="velocity-section-title" style="margin-top: 1.25rem;">Top Spends</div>
+            <div id="topSpends"></div>
 
             <!-- Smart Alert -->
             <div class="smart-alert" id="smartAlert">

--- a/static/expenses.html
+++ b/static/expenses.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1777669514">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
 </head>
 <body>
     <nav-bar></nav-bar>
@@ -50,17 +50,17 @@
     </div>
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778016442"></script>
-    <script type="module" src="/static/components/api-service.js?v=1778016442"></script>
-    <script type="module" src="/static/components/event-manager.js?v=1778016442"></script>
+    <script type="module" src="/static/components/config.js?v=1778100000"></script>
+    <script type="module" src="/static/components/api-service.js?v=1778100000"></script>
+    <script type="module" src="/static/components/event-manager.js?v=1778100000"></script>
 
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778016442"></script>
-    <script type="module" src="/static/components/toast.js?v=1778016442"></script>
-    <script type="module" src="/static/components/date-navigation.js?v=1778016442"></script>
-    <script type="module" src="/static/components/category-chart.js?v=1778016442"></script>
-    <script type="module" src="/static/components/backup-button.js?v=1778016442"></script>
-    <script type="module" src="/static/components/latest-expenses.js?v=1778016442"></script>
+    <script src="/static/components/navbar.js?v=1778100000"></script>
+    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
+    <script type="module" src="/static/components/date-navigation.js?v=1778100000"></script>
+    <script type="module" src="/static/components/category-chart.js?v=1778100000"></script>
+    <script type="module" src="/static/components/backup-button.js?v=1778100000"></script>
+    <script type="module" src="/static/components/latest-expenses.js?v=1778100000"></script>
 
 
 </body>

--- a/static/index.html
+++ b/static/index.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1777669514">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
 </head>
 <body>
     <nav-bar></nav-bar>
@@ -59,10 +59,10 @@
     </div>
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778016442"></script>
+    <script type="module" src="/static/components/config.js?v=1778100000"></script>
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778016442"></script>
-    <script type="module" src="/static/components/toast.js?v=1778016442"></script>
-    <script type="module" src="/static/components/latest-expenses.js?v=1778016442"></script>
+    <script src="/static/components/navbar.js?v=1778100000"></script>
+    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
+    <script type="module" src="/static/components/latest-expenses.js?v=1778100000"></script>
 </body>
 </html>

--- a/static/recurring.html
+++ b/static/recurring.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1777669514">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
 </head>
 <body>
     <nav-bar></nav-bar>
@@ -49,15 +49,15 @@
 
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778016442"></script>
-    <script type="module" src="/static/components/api-service.js?v=1778016442"></script>
-    <script type="module" src="/static/components/event-manager.js?v=1778016442"></script>
+    <script type="module" src="/static/components/config.js?v=1778100000"></script>
+    <script type="module" src="/static/components/api-service.js?v=1778100000"></script>
+    <script type="module" src="/static/components/event-manager.js?v=1778100000"></script>
 
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778016442"></script>
-    <script type="module" src="/static/components/toast.js?v=1778016442"></script>
-    <script type="module" src="/static/components/recurring-list.js?v=1778016442"></script>
-    <script type="module" src="/static/components/recurring-form.js?v=1778016442"></script>
+    <script src="/static/components/navbar.js?v=1778100000"></script>
+    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
+    <script type="module" src="/static/components/recurring-list.js?v=1778100000"></script>
+    <script type="module" src="/static/components/recurring-form.js?v=1778100000"></script>
     <recurring-form></recurring-form>
 
 

--- a/static/styles/vault-theme.css
+++ b/static/styles/vault-theme.css
@@ -336,10 +336,9 @@ a:hover { color: var(--primary-fixed-dim); }
 /* Bottom nav */
 .bottom-nav {
     position: fixed;
-    bottom: 0;
+    bottom: env(safe-area-inset-bottom, 0px);
     left: 0;
     right: 0;
-    padding-bottom: env(safe-area-inset-bottom);
     background: rgba(14, 14, 14, 0.8);
     backdrop-filter: blur(var(--glass-blur));
     -webkit-backdrop-filter: blur(var(--glass-blur));
@@ -348,9 +347,25 @@ a:hover { color: var(--primary-fixed-dim); }
     display: flex;
     justify-content: space-around;
     align-items: center;
-    height: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
+    height: var(--bottom-nav-height);
     padding-left: 0.5rem;
     padding-right: 0.5rem;
+    padding-bottom: 0;
+}
+
+/* Fills the safe-area gap below the nav with a matching background */
+.bottom-nav::after {
+    content: '';
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: env(safe-area-inset-bottom, 0px);
+    background: rgba(14, 14, 14, 0.8);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    z-index: 1029;
+    pointer-events: none;
 }
 
 .bottom-nav-item {

--- a/static/trends.html
+++ b/static/trends.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1777669514">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
 </head>
 <body>
     <nav-bar></nav-bar>
@@ -40,13 +40,13 @@
     </div>
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778016442"></script>
-    <script type="module" src="/static/components/api-service.js?v=1778016442"></script>
-    <script type="module" src="/static/components/event-manager.js?v=1778016442"></script>
+    <script type="module" src="/static/components/config.js?v=1778100000"></script>
+    <script type="module" src="/static/components/api-service.js?v=1778100000"></script>
+    <script type="module" src="/static/components/event-manager.js?v=1778100000"></script>
 
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778016442"></script>
-    <script type="module" src="/static/components/toast.js?v=1778016442"></script>
-    <script type="module" src="/static/components/spending-trends.js?v=1778016442"></script>
+    <script src="/static/components/navbar.js?v=1778100000"></script>
+    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
+    <script type="module" src="/static/components/spending-trends.js?v=1778100000"></script>
 </body>
 </html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime
-from app import Expense
+from app import Expense, db
 
 
 @pytest.fixture(autouse=True)
@@ -193,3 +193,57 @@ def test_expense_validation(client):
     }
     response = client.post("/api/expenses", json=invalid_expense)
     assert response.status_code == 400
+
+
+def test_trends_includes_categories(client):
+    """GET /api/trends includes per-category totals for each period."""
+    with client.application.app_context():
+        today = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+        db.session.add(
+            Expense(
+                amount=50.0,
+                category="food_drink",
+                description="test",
+                date=today,
+            )
+        )
+        db.session.commit()
+
+    resp = client.get("/api/trends")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    for period in data["weekly"]:
+        assert "categories" in period
+        assert isinstance(period["categories"], dict)
+    for period in data["monthly"]:
+        assert "categories" in period
+
+    assert "top_expenses" in data["weekly"][3]
+    assert isinstance(data["weekly"][3]["top_expenses"], list)
+    assert "top_expenses" in data["monthly"][3]
+
+
+def test_trends_top_expenses_sorted_by_amount(client):
+    """Current period top_expenses are ordered by amount descending, max 5."""
+    with client.application.app_context():
+        today = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+        for amount in [10.0, 50.0, 30.0, 80.0, 20.0, 60.0]:
+            db.session.add(
+                Expense(
+                    amount=amount,
+                    category="food_drink",
+                    description=f"expense {amount}",
+                    date=today,
+                )
+            )
+        db.session.commit()
+
+    resp = client.get("/api/trends")
+    data = resp.get_json()
+    top = data["weekly"][3]["top_expenses"]
+
+    assert len(top) <= 5
+    amounts = [e["amount"] for e in top]
+    assert amounts == sorted(amounts, reverse=True)
+    assert top[0]["amount"] == 80.0

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -335,6 +335,32 @@ def test_manual_apply_endpoint(client):
     assert json_data["applied"] == 1
 
 
+def test_never_applied_recurring_only_fires_on_correct_day(client):
+    """A never-applied monthly recurring should NOT fire on the wrong day of month."""
+    with app.app_context():
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        wrong_day = (today.day % 28) + 1  # guaranteed different from today
+
+        recurring = RecurringExpense(
+            amount=99.0,
+            category="housing",
+            description="Rent wrong day",
+            frequency="monthly",
+            day_of_month=wrong_day,
+            start_date=today - timedelta(days=60),
+            is_active=True,
+            last_applied_date=None,
+        )
+        db.session.add(recurring)
+        db.session.commit()
+
+        count = apply_due_recurring_expenses()
+        assert count == 0, "Should not fire on wrong day even when never applied"
+
+        expenses = Expense.query.filter_by(description="Rent wrong day").all()
+        assert len(expenses) == 0
+
+
 def test_pending_recurring_endpoint(client):
     """Test the pending recurring expenses endpoint."""
     with app.app_context():

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -213,9 +213,7 @@ def test_is_due_today_weekly():
 def test_apply_due_recurring_expenses(client):
     """Test applying due recurring expenses."""
     with app.app_context():
-        today = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
         # Create a due recurring expense
         recurring = RecurringExpense(
@@ -245,9 +243,7 @@ def test_apply_due_recurring_expenses(client):
 def test_no_duplicate_expenses(client):
     """Test that duplicate expenses are not created."""
     with app.app_context():
-        today = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
         # Create a recurring expense
         recurring = RecurringExpense(
@@ -309,9 +305,7 @@ def test_inactive_recurring_not_applied(client):
 def test_manual_apply_endpoint(client):
     """Test the manual apply endpoint."""
     with app.app_context():
-        today = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
         # Create a due recurring expense
         recurring = RecurringExpense(


### PR DESCRIPTION
Fixes three bugs and adds a new feature to the trends page:

- **Recurring double-apply**: never-applied recurring expenses were firing every day regardless of their scheduled day. Fixed with a far-past sentinel so frequency logic decides correctly.
- **PWA bottom nav**: buttons appeared too high on iOS home screen mode. Fixed with `env(safe-area-inset-bottom)` and an `::after` fill layer.
- **Trends category velocity**: was always empty because the backend wasn't returning per-category totals. Added `GROUP BY category` query and wired it to the frontend.
- **Trends smart alert + daily avg**: alert was gated on an always-empty array; daily avg used `getDay()` on a rolling 7-day window (always 7). Both fixed.
- **Top Spends**: new section on the trends page showing the top 5 expenses for the current period, sorted by amount.