### PR TITLE
fix: bottom nav safe-area clipping in PWA

### DIFF
--- a/static/add-expense.html
+++ b/static/add-expense.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
 <style>#submitBtn { position: relative; z-index: 9999; pointer-events: auto !important; }</style>
 </head>
 <body>

--- a/static/expenses.html
+++ b/static/expenses.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
 </head>
 <body>
     <nav-bar></nav-bar>

--- a/static/index.html
+++ b/static/index.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
 </head>
 <body>
     <nav-bar></nav-bar>

--- a/static/recurring.html
+++ b/static/recurring.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
 </head>
 <body>
     <nav-bar></nav-bar>

--- a/static/styles/vault-theme.css
+++ b/static/styles/vault-theme.css
@@ -336,7 +336,7 @@ a:hover { color: var(--primary-fixed-dim); }
 /* Bottom nav */
 .bottom-nav {
     position: fixed;
-    bottom: env(safe-area-inset-bottom, 0px);
+    bottom: 0;
     left: 0;
     right: 0;
     background: rgba(14, 14, 14, 0.8);
@@ -347,25 +347,14 @@ a:hover { color: var(--primary-fixed-dim); }
     display: flex;
     justify-content: space-around;
     align-items: center;
-    height: var(--bottom-nav-height);
+    /* Items stay centered in the top --bottom-nav-height band; the safe-area
+       padding extends the bar (and its background) down through the iOS
+       home-indicator zone so it reaches the screen edge without lifting the
+       buttons up. */
+    height: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
     padding-left: 0.5rem;
     padding-right: 0.5rem;
-    padding-bottom: 0;
-}
-
-/* Fills the safe-area gap below the nav with a matching background */
-.bottom-nav::after {
-    content: '';
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: env(safe-area-inset-bottom, 0px);
-    background: rgba(14, 14, 14, 0.8);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    z-index: 1029;
-    pointer-events: none;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .bottom-nav-item {

--- a/static/trends.html
+++ b/static/trends.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778100000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
 </head>
 <body>
     <nav-bar></nav-bar>


### PR DESCRIPTION
Fixes the bottom navigation bar clipping its labels and bleeding content through in iOS PWA (home screen) mode.

The previous attempt lifted the whole bar up by the home-indicator height, which clipped the button labels. This anchors the bar at the screen edge and grows it downward into the safe-area zone instead, so buttons stay centered in the visible band and the background fills through to the bottom — the native iOS tab-bar pattern.