### PR TITLE
Fix .dockyard.json so the Flask dev server starts in Dockyard

### DIFF
--- a/.dockyard.json
+++ b/.dockyard.json
@@ -1,4 +1,4 @@
 {
-  "start": "python app.py",
-  "port": 5001
+  "setup": "python3 -m venv venv && ./venv/bin/pip install -r requirements.txt -r requirements-dev.txt",
+  "run": "./venv/bin/python app.py"
 }


### PR DESCRIPTION
The committed `.dockyard.json` used `start`/`port` keys, which Dockyard ignores — it reads `setup`/`run`/`teardown`, so the config was treated as empty and the app never launched.

This switches to a per-worktree venv for `setup` and runs the dev server directly for `run`, so Dockyard's `dy-run` launcher can auto-detect port 5001 and retarget the built-in browser. Sticking with venv rather than the existing `compose.yml` keeps hot reload working, lets port auto-detection see the listener as a child process, and avoids container-name/port collisions across parallel worktrees. Docker stays for production on the Pi.