### PR TITLE
Polish UI: tabular numbers, transition specificity, press feedback, text-wrap

### DIFF
--- a/static/add-expense.html
+++ b/static/add-expense.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1782587681">
 <style>#submitBtn { position: relative; z-index: 9999; pointer-events: auto !important; }</style>
 </head>
 <body>
@@ -74,14 +74,14 @@
     </div>
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778100000"></script>
-    <script type="module" src="/static/components/api-service.js?v=1778100000"></script>
-    <script type="module" src="/static/components/event-manager.js?v=1778100000"></script>
+    <script type="module" src="/static/components/config.js?v=1782587681"></script>
+    <script type="module" src="/static/components/api-service.js?v=1782587681"></script>
+    <script type="module" src="/static/components/event-manager.js?v=1782587681"></script>
 
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778100000"></script>
-    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
-    <script type="module" src="/static/components/add-expense-form.js?v=1778100000"></script>
+    <script src="/static/components/navbar.js?v=1782587681"></script>
+    <script type="module" src="/static/components/toast.js?v=1782587681"></script>
+    <script type="module" src="/static/components/add-expense-form.js?v=1782587681"></script>
 
 
 </body>

--- a/static/components/add-expense-form.js
+++ b/static/components/add-expense-form.js
@@ -55,7 +55,7 @@ class AddExpenseForm extends BaseComponent {
                                name="amount"
                                inputmode="decimal"
                                placeholder="0.00"
-                               style="font-family: 'Manrope', sans-serif; font-size: 2rem; font-weight: 800;"
+                               style="font-family: 'Manrope', sans-serif; font-size: 2rem; font-weight: 800; font-variant-numeric: tabular-nums;"
                                required>
                     </div>
                 </div>
@@ -117,7 +117,7 @@ class AddExpenseForm extends BaseComponent {
             e.preventDefault();
             this.handleSubmit(e);
         });
-        
+
         const submitBtn = this.querySelector('#submitBtn');
         this.addEventListenerWithCleanup(submitBtn, 'click', (e) => {
             e.preventDefault();
@@ -145,7 +145,7 @@ class AddExpenseForm extends BaseComponent {
             this.querySelector('#amount').value = this.editData.amount;
             this.querySelector('#category').value = this.editData.category;
             this.querySelector('#description').value = decodeURIComponent(this.editData.description);
-            
+
             if (this.editData.date && this.editData.date !== 'undefined' && this.editData.date !== 'null') {
                 // Parse the date to YYYY-MM-DD for the date input
                 const d = new Date(this.editData.date);
@@ -302,7 +302,7 @@ class AddExpenseForm extends BaseComponent {
             <div class="card-vault" style="text-align: left;">
                 <div class="d-flex justify-content-between mb-2">
                     <span class="text-muted">Amount</span>
-                    <span class="fw-bold" style="color: var(--primary);">${CurrencyHelper.format(expense.amount)}</span>
+                    <span class="fw-bold tabular-nums" style="color: var(--primary);">${CurrencyHelper.format(expense.amount)}</span>
                 </div>
                 <div class="d-flex justify-content-between mb-2">
                     <span class="text-muted">Category</span>

--- a/static/components/backup-button.js
+++ b/static/components/backup-button.js
@@ -115,7 +115,7 @@ class BackupButton extends BaseComponent {
                     background: var(--surface-container-low);
                     color: var(--on-surface);
                     cursor: pointer;
-                    transition: all 0.15s;
+                    transition: background-color 0.15s;
                     text-align: left;
                     width: 100%;
                 }

--- a/static/components/category-chart.js
+++ b/static/components/category-chart.js
@@ -408,6 +408,7 @@ class CategoryChart extends BaseComponent {
                     font-size: 0.8125rem;
                     color: var(--on-surface);
                     white-space: nowrap;
+                    font-variant-numeric: tabular-nums;
                 }
                 .legend-pct {
                     font-size: 0.6875rem;
@@ -537,6 +538,7 @@ class CategoryChart extends BaseComponent {
                     color: var(--on-surface);
                     margin-left: 1rem;
                     flex-shrink: 0;
+                    font-variant-numeric: tabular-nums;
                 }
             </style>
 

--- a/static/components/date-navigation.js
+++ b/static/components/date-navigation.js
@@ -66,7 +66,7 @@ class DateNavigation extends BaseComponent {
                     background: rgba(255, 255, 255, 0.06);
                     color: var(--on-surface-variant);
                     cursor: pointer;
-                    transition: all 0.15s ease;
+                    transition: background-color 0.15s ease, color 0.15s ease;
                     border: none;
                     font-family: 'Inter', sans-serif;
                 }

--- a/static/components/expense-list.js
+++ b/static/components/expense-list.js
@@ -112,6 +112,7 @@ class ExpenseList extends BaseComponent {
                     font-size: 0.9375rem;
                     color: var(--on-surface);
                     flex-shrink: 0;
+                    font-variant-numeric: tabular-nums;
                 }
                 .empty-state {
                     text-align: center;

--- a/static/components/latest-expenses.js
+++ b/static/components/latest-expenses.js
@@ -107,7 +107,7 @@ class LatestExpenses extends BaseComponent {
                     font-weight: 600;
                     font-family: 'Inter', sans-serif;
                     cursor: pointer;
-                    transition: all 0.15s ease;
+                    transition: background-color 0.15s ease, color 0.15s ease;
                     min-width: 50px;
                 }
 
@@ -164,7 +164,7 @@ class LatestExpenses extends BaseComponent {
                 }
                 .swipe-action-edit { background: var(--primary-container); color: var(--on-primary); }
                 .swipe-action-delete { background: var(--error-container); color: var(--on-error-container); }
-                .swipe-action:active { opacity: 0.8; transform: scale(0.95); }
+                .swipe-action:active { opacity: 0.8; transform: scale(0.96); }
 
                 .expense-item {
                     position: relative;
@@ -200,6 +200,7 @@ class LatestExpenses extends BaseComponent {
                     font-family: 'Manrope', sans-serif;
                     font-size: 1rem;
                     font-weight: 700;
+                    font-variant-numeric: tabular-nums;
                 }
 
                 .expense-description {
@@ -532,7 +533,7 @@ class LatestExpenses extends BaseComponent {
                     this.activeSwipeItem = null;
                     return;
                 }
-                
+
                 // Otherwise, clicking the item directly opens the Edit page
                 this.editExpense(expense);
             });

--- a/static/components/recurring-list.js
+++ b/static/components/recurring-list.js
@@ -102,7 +102,7 @@ class RecurringList extends BaseComponent {
         // Calculate monthly commitment
         let totalMonthly = 0;
         const activeCount = this.recurringExpenses.filter(r => r.is_active).length;
-        
+
         this.recurringExpenses.forEach(r => {
             if (!r.is_active) return;
             const amt = parseFloat(r.amount);
@@ -110,7 +110,7 @@ class RecurringList extends BaseComponent {
             else if (r.frequency === 'weekly') totalMonthly += (amt * 52) / 12;
             else if (r.frequency === 'yearly') totalMonthly += amt / 12;
         });
-        
+
         const formattedTotal = CurrencyHelper.format(totalMonthly);
 
         this.innerHTML = `
@@ -258,7 +258,7 @@ class RecurringList extends BaseComponent {
                     display: flex;
                     align-items: center;
                     justify-content: center;
-                    transition: all 0.15s;
+                    transition: background-color 0.15s, color 0.15s;
                 }
                 .recurring-action-btn:hover {
                     background: rgba(255, 140, 0, 0.2);
@@ -300,7 +300,7 @@ class RecurringList extends BaseComponent {
                     bottom: 3px;
                     background: var(--outline);
                     border-radius: 50%;
-                    transition: all 0.2s;
+                    transition: transform 0.2s, background-color 0.2s;
                 }
                 .toggle-switch input:checked + .toggle-slider {
                     background: var(--primary-container);
@@ -355,7 +355,7 @@ class RecurringList extends BaseComponent {
                         <div class="recurring-meta">
                             <span class="recurring-meta-item">
                                 <span class="material-symbols-outlined">payments</span>
-                                <strong>${CurrencyHelper.format(recurring.amount)}</strong>
+                                <strong class="tabular-nums">${CurrencyHelper.format(recurring.amount)}</strong>
                             </span>
                             <span class="recurring-meta-item">
                                 <span class="material-symbols-outlined">repeat</span>

--- a/static/components/spending-trends.js
+++ b/static/components/spending-trends.js
@@ -320,7 +320,7 @@ class SpendingTrends extends BaseComponent {
                     text-transform: uppercase;
                     letter-spacing: 0.1em;
                     cursor: pointer;
-                    transition: all 0.2s;
+                    transition: color 0.2s, background-color 0.2s;
                     background: transparent;
                     color: var(--on-surface-variant);
                 }
@@ -359,6 +359,7 @@ class SpendingTrends extends BaseComponent {
                     font-size: 1.75rem;
                     font-weight: 800;
                     color: var(--on-surface);
+                    font-variant-numeric: tabular-nums;
                 }
                 .delta-text {
                     font-size: 0.8125rem;
@@ -426,6 +427,7 @@ class SpendingTrends extends BaseComponent {
                     font-size: 0.5625rem;
                     color: var(--outline);
                     font-weight: 600;
+                    font-variant-numeric: tabular-nums;
                 }
 
                 /* Stats grid */
@@ -458,6 +460,7 @@ class SpendingTrends extends BaseComponent {
                     font-size: 1.375rem;
                     font-weight: 800;
                     color: var(--on-surface);
+                    font-variant-numeric: tabular-nums;
                 }
 
                 /* Category velocity */
@@ -517,6 +520,7 @@ class SpendingTrends extends BaseComponent {
                     font-weight: 800;
                     font-size: 1rem;
                     color: var(--on-surface);
+                    font-variant-numeric: tabular-nums;
                 }
                 .velocity-delta.delta-up { color: var(--error); }
                 .velocity-delta.delta-down { color: var(--tertiary); }

--- a/static/expenses.html
+++ b/static/expenses.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1782587681">
 </head>
 <body>
     <nav-bar></nav-bar>
@@ -50,17 +50,17 @@
     </div>
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778100000"></script>
-    <script type="module" src="/static/components/api-service.js?v=1778100000"></script>
-    <script type="module" src="/static/components/event-manager.js?v=1778100000"></script>
+    <script type="module" src="/static/components/config.js?v=1782587681"></script>
+    <script type="module" src="/static/components/api-service.js?v=1782587681"></script>
+    <script type="module" src="/static/components/event-manager.js?v=1782587681"></script>
 
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778100000"></script>
-    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
-    <script type="module" src="/static/components/date-navigation.js?v=1778100000"></script>
-    <script type="module" src="/static/components/category-chart.js?v=1778100000"></script>
-    <script type="module" src="/static/components/backup-button.js?v=1778100000"></script>
-    <script type="module" src="/static/components/latest-expenses.js?v=1778100000"></script>
+    <script src="/static/components/navbar.js?v=1782587681"></script>
+    <script type="module" src="/static/components/toast.js?v=1782587681"></script>
+    <script type="module" src="/static/components/date-navigation.js?v=1782587681"></script>
+    <script type="module" src="/static/components/category-chart.js?v=1782587681"></script>
+    <script type="module" src="/static/components/backup-button.js?v=1782587681"></script>
+    <script type="module" src="/static/components/latest-expenses.js?v=1782587681"></script>
 
 
 </body>

--- a/static/index.html
+++ b/static/index.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1782587681">
 </head>
 <body>
     <nav-bar></nav-bar>
@@ -59,10 +59,10 @@
     </div>
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778100000"></script>
+    <script type="module" src="/static/components/config.js?v=1782587681"></script>
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778100000"></script>
-    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
-    <script type="module" src="/static/components/latest-expenses.js?v=1778100000"></script>
+    <script src="/static/components/navbar.js?v=1782587681"></script>
+    <script type="module" src="/static/components/toast.js?v=1782587681"></script>
+    <script type="module" src="/static/components/latest-expenses.js?v=1782587681"></script>
 </body>
 </html>

--- a/static/recurring.html
+++ b/static/recurring.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1782587681">
 </head>
 <body>
     <nav-bar></nav-bar>
@@ -49,15 +49,15 @@
 
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778100000"></script>
-    <script type="module" src="/static/components/api-service.js?v=1778100000"></script>
-    <script type="module" src="/static/components/event-manager.js?v=1778100000"></script>
+    <script type="module" src="/static/components/config.js?v=1782587681"></script>
+    <script type="module" src="/static/components/api-service.js?v=1782587681"></script>
+    <script type="module" src="/static/components/event-manager.js?v=1782587681"></script>
 
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778100000"></script>
-    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
-    <script type="module" src="/static/components/recurring-list.js?v=1778100000"></script>
-    <script type="module" src="/static/components/recurring-form.js?v=1778100000"></script>
+    <script src="/static/components/navbar.js?v=1782587681"></script>
+    <script type="module" src="/static/components/toast.js?v=1782587681"></script>
+    <script type="module" src="/static/components/recurring-list.js?v=1782587681"></script>
+    <script type="module" src="/static/components/recurring-form.js?v=1782587681"></script>
     <recurring-form></recurring-form>
 
 

--- a/static/styles/vault-theme.css
+++ b/static/styles/vault-theme.css
@@ -141,13 +141,13 @@ a:hover { color: var(--primary-fixed-dim); }
 .font-body { font-family: 'Inter', sans-serif; }
 
 /* Display / Headline sizes */
-.text-display-lg { font-size: 3.5rem; font-weight: 800; letter-spacing: -0.02em; line-height: 1; }
-.text-headline-lg { font-size: 2rem; font-weight: 800; letter-spacing: -0.01em; }
-.text-headline-md { font-size: 1.5rem; font-weight: 700; }
-.text-headline-sm { font-size: 1.25rem; font-weight: 700; }
-.text-body-lg { font-size: 1rem; font-weight: 400; }
-.text-body-md { font-size: 0.875rem; font-weight: 400; }
-.text-body-sm { font-size: 0.75rem; font-weight: 400; }
+.text-display-lg { font-size: 3.5rem; font-weight: 800; letter-spacing: -0.02em; line-height: 1; text-wrap: balance; }
+.text-headline-lg { font-size: 2rem; font-weight: 800; letter-spacing: -0.01em; text-wrap: balance; }
+.text-headline-md { font-size: 1.5rem; font-weight: 700; text-wrap: balance; }
+.text-headline-sm { font-size: 1.25rem; font-weight: 700; text-wrap: balance; }
+.text-body-lg { font-size: 1rem; font-weight: 400; text-wrap: pretty; }
+.text-body-md { font-size: 0.875rem; font-weight: 400; text-wrap: pretty; }
+.text-body-sm { font-size: 0.75rem; font-weight: 400; text-wrap: pretty; }
 .text-label-lg { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.15em; }
 .text-label-sm { font-size: 0.625rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.2em; }
 
@@ -373,7 +373,7 @@ a:hover { color: var(--primary-fixed-dim); }
     text-transform: uppercase;
     letter-spacing: 0.15em;
     -webkit-tap-highlight-color: transparent;
-    transition: all 0.15s ease;
+    transition: color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
 }
@@ -424,7 +424,7 @@ a:hover { color: var(--primary-fixed-dim); }
 }
 
 .fab-add-btn:active {
-    transform: scale(0.95);
+    transform: scale(0.96);
 }
 
 .fab-add-btn .material-symbols-outlined {
@@ -496,6 +496,7 @@ a:hover { color: var(--primary-fixed-dim); }
     font-weight: 700;
     color: var(--on-surface);
     margin-bottom: 1rem;
+    text-wrap: balance;
 }
 
 /* ============================================================
@@ -511,7 +512,7 @@ a:hover { color: var(--primary-fixed-dim); }
     font-family: 'Inter', sans-serif;
     padding: 0.75rem 1.25rem;
     cursor: pointer;
-    transition: all 0.15s ease;
+    transition: background-color 0.15s ease, transform 0.15s ease;
     text-decoration: none;
     font-size: 0.875rem;
     line-height: 1.5;
@@ -520,7 +521,7 @@ a:hover { color: var(--primary-fixed-dim); }
 }
 
 .btn:hover { background: var(--surface-bright); }
-.btn:active { transform: scale(0.98); }
+.btn:active { transform: scale(0.96); }
 .btn:disabled { opacity: 0.5; pointer-events: none; }
 
 .btn-primary {
@@ -582,6 +583,11 @@ a:hover { color: var(--primary-fixed-dim); }
 .btn-sm { padding: 0.375rem 0.75rem; font-size: 0.8125rem; }
 .btn-lg { padding: 1rem 1.5rem; font-size: 1rem; }
 .btn-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 40px;
+    min-height: 40px;
     background: none;
     border: none;
     color: var(--on-surface-variant);
@@ -616,7 +622,7 @@ a:hover { color: var(--primary-fixed-dim); }
     font-size: 1rem;
     cursor: pointer;
     text-decoration: none;
-    transition: all 0.15s ease;
+    transition: background-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .btn-modern-primary {
@@ -722,6 +728,7 @@ a:hover { color: var(--primary-fixed-dim); }
     font-size: 0.75rem;
     color: var(--on-surface-variant);
     margin-top: 0.25rem;
+    text-wrap: pretty;
 }
 
 .form-select {
@@ -1178,7 +1185,7 @@ a:hover { color: var(--primary-fixed-dim); }
 .modal-header { display: flex; align-items: center; justify-content: space-between; padding: 1.25rem 1.5rem; }
 .modal-body { padding: 1.5rem; }
 .modal-footer { display: flex; justify-content: flex-end; gap: 0.75rem; padding: 1rem 1.5rem; }
-.modal-title { font-family: 'Manrope', sans-serif; font-weight: 700; font-size: 1.125rem; }
+.modal-title { font-family: 'Manrope', sans-serif; font-weight: 700; font-size: 1.125rem; text-wrap: balance; }
 
 /* ============================================================
    25. SVG Donut Chart
@@ -1309,7 +1316,7 @@ a:hover { color: var(--primary-fixed-dim); }
     border-radius: 0.75rem;
     padding: 1.25rem;
     border-left: 4px solid rgba(86, 67, 52, 0.3);
-    transition: all 0.15s ease;
+    transition: border-left-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .inbox-card.matched {
@@ -1322,3 +1329,8 @@ a:hover { color: var(--primary-fixed-dim); }
    ============================================================ */
 .transition-all { transition: all 0.15s ease; }
 .transition-colors { transition: color 0.15s ease, background-color 0.15s ease; }
+
+/* ============================================================
+   32. Tabular numbers (equal-width digits for amounts/dates)
+   ============================================================ */
+.tabular-nums { font-variant-numeric: tabular-nums; }

--- a/static/trends.html
+++ b/static/trends.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 
     <!-- Vault Theme -->
-    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1778200000">
+    <link rel="stylesheet" href="/static/styles/vault-theme.css?v=1782587681">
 </head>
 <body>
     <nav-bar></nav-bar>
@@ -40,13 +40,13 @@
     </div>
 
     <!-- Core Modules -->
-    <script type="module" src="/static/components/config.js?v=1778100000"></script>
-    <script type="module" src="/static/components/api-service.js?v=1778100000"></script>
-    <script type="module" src="/static/components/event-manager.js?v=1778100000"></script>
+    <script type="module" src="/static/components/config.js?v=1782587681"></script>
+    <script type="module" src="/static/components/api-service.js?v=1782587681"></script>
+    <script type="module" src="/static/components/event-manager.js?v=1782587681"></script>
 
     <!-- Custom Components -->
-    <script src="/static/components/navbar.js?v=1778100000"></script>
-    <script type="module" src="/static/components/toast.js?v=1778100000"></script>
-    <script type="module" src="/static/components/spending-trends.js?v=1778100000"></script>
+    <script src="/static/components/navbar.js?v=1782587681"></script>
+    <script type="module" src="/static/components/toast.js?v=1782587681"></script>
+    <script type="module" src="/static/components/spending-trends.js?v=1782587681"></script>
 </body>
 </html>


### PR DESCRIPTION
Applies design-detail polish across the frontend using the make-interfaces-feel-better principles, with no behaviour or backend changes.

Amounts everywhere now use tabular numbers so they stop shifting width as digits change — including the live amount input while typing. Every `transition: all` is replaced with the specific properties that actually animate, press feedback is standardised to `scale(0.96)`, headings get `text-wrap: balance` and body/help text `text-wrap: pretty`, and the close button gets a proper 40x40 touch target.

The asset `?v=` cache strings are bumped so the changes show up on a normal reload rather than needing a hard refresh once this deploys to staging.